### PR TITLE
refactor size formatting helper

### DIFF
--- a/cmd/project.go
+++ b/cmd/project.go
@@ -109,8 +109,8 @@ func newProjectListCmd() *cobra.Command {
 						// Get project summary for quota info
 						summary, err := projectSvc.GetSummary(p.Name)
 						if err == nil && summary.Quota != nil {
-							storageLimit := harbor.FormatStorageSize(summary.Quota.Hard.Storage)
-							storageUsed := harbor.FormatStorageSize(summary.Quota.Used.Storage)
+							storageLimit := output.FormatSize(summary.Quota.Hard.Storage)
+							storageUsed := output.FormatSize(summary.Quota.Used.Storage)
 							row = append(row, storageLimit, storageUsed)
 						} else {
 							row = append(row, "N/A", "N/A")
@@ -149,7 +149,7 @@ func newProjectCreateCmd() *cobra.Command {
 		proxyCache   bool
 		registryID   int64
 		proxySpeedKB int64
-		registryName   string
+		registryName string
 	)
 
 	cmd := &cobra.Command{
@@ -247,7 +247,7 @@ func newProjectCreateCmd() *cobra.Command {
 				}
 				metadata.ProxySpeedKB = fmt.Sprintf("%d", proxySpeedKB)
 			}
-			
+
 			// Set registry ID for proxy cache at project level
 			if proxyCache {
 				req.RegistryID = &registryID
@@ -396,11 +396,11 @@ func newProjectGetCmd() *cobra.Command {
 					if summary.Quota != nil {
 						fmt.Printf(
 							"  Storage Limit:    %s\n",
-							harbor.FormatStorageSize(summary.Quota.Hard.Storage),
+							output.FormatSize(summary.Quota.Hard.Storage),
 						)
 						fmt.Printf(
 							"  Storage Used:     %s\n",
-							harbor.FormatStorageSize(summary.Quota.Used.Storage),
+							output.FormatSize(summary.Quota.Used.Storage),
 						)
 						if summary.Quota.Hard.Storage > 0 {
 							percentage := float64(

--- a/cmd/project.go.bak2
+++ b/cmd/project.go.bak2
@@ -109,8 +109,8 @@ func newProjectListCmd() *cobra.Command {
 						// Get project summary for quota info
 						summary, err := projectSvc.GetSummary(p.Name)
 						if err == nil && summary.Quota != nil {
-							storageLimit := harbor.FormatStorageSize(summary.Quota.Hard.Storage)
-							storageUsed := harbor.FormatStorageSize(summary.Quota.Used.Storage)
+							storageLimit := output.FormatSize(summary.Quota.Hard.Storage)
+							storageUsed := output.FormatSize(summary.Quota.Used.Storage)
 							row = append(row, storageLimit, storageUsed)
 						} else {
 							row = append(row, "N/A", "N/A")
@@ -353,11 +353,11 @@ func newProjectGetCmd() *cobra.Command {
 					if summary.Quota != nil {
 						fmt.Printf(
 							"  Storage Limit:    %s\n",
-							harbor.FormatStorageSize(summary.Quota.Hard.Storage),
+							output.FormatSize(summary.Quota.Hard.Storage),
 						)
 						fmt.Printf(
 							"  Storage Used:     %s\n",
-							harbor.FormatStorageSize(summary.Quota.Used.Storage),
+							output.FormatSize(summary.Quota.Used.Storage),
 						)
 						if summary.Quota.Hard.Storage > 0 {
 							percentage := float64(

--- a/pkg/harbor/project.go
+++ b/pkg/harbor/project.go
@@ -22,7 +22,7 @@ func NewProjectService(client *api.Client) *ProjectService {
 // List lists projects
 func (s *ProjectService) List(opts *api.ListOptions) ([]*api.Project, error) {
 	params := make(map[string]string)
-	
+
 	if opts != nil {
 		if opts.Page > 0 {
 			params["page"] = strconv.Itoa(opts.Page)
@@ -37,17 +37,17 @@ func (s *ProjectService) List(opts *api.ListOptions) ([]*api.Project, error) {
 			params["sort"] = opts.Sort
 		}
 	}
-	
+
 	resp, err := s.client.Get("/projects", params)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	var projects []*api.Project
 	if err := s.client.DecodeResponse(resp, &projects); err != nil {
 		return nil, fmt.Errorf("failed to decode projects: %w", err)
 	}
-	
+
 	return projects, nil
 }
 
@@ -57,12 +57,12 @@ func (s *ProjectService) Get(nameOrID string) (*api.Project, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	var project api.Project
 	if err := s.client.DecodeResponse(resp, &project); err != nil {
 		return nil, fmt.Errorf("failed to decode project: %w", err)
 	}
-	
+
 	return &project, nil
 }
 
@@ -73,11 +73,11 @@ func (s *ProjectService) Create(req *api.ProjectReq) error {
 		return err
 	}
 	defer resp.Body.Close()
-	
+
 	if resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
-	
+
 	return nil
 }
 
@@ -88,11 +88,11 @@ func (s *ProjectService) Update(nameOrID string, req *api.ProjectReq) error {
 		return err
 	}
 	defer resp.Body.Close()
-	
+
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
-	
+
 	return nil
 }
 
@@ -103,11 +103,11 @@ func (s *ProjectService) Delete(nameOrID string) error {
 		return err
 	}
 	defer resp.Body.Close()
-	
+
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
-	
+
 	return nil
 }
 
@@ -117,12 +117,12 @@ func (s *ProjectService) GetSummary(nameOrID string) (*api.ProjectSummary, error
 	if err != nil {
 		return nil, err
 	}
-	
+
 	var summary api.ProjectSummary
 	if err := s.client.DecodeResponse(resp, &summary); err != nil {
 		return nil, fmt.Errorf("failed to decode project summary: %w", err)
 	}
-	
+
 	return &summary, nil
 }
 
@@ -136,7 +136,7 @@ func (s *ProjectService) Exists(projectName string) (bool, error) {
 		return false, err
 	}
 	defer resp.Body.Close()
-	
+
 	return resp.StatusCode == http.StatusOK, nil
 }
 
@@ -153,12 +153,12 @@ func ParseStorageLimit(limit string) (int64, error) {
 	if limit == "" || limit == "-1" {
 		return -1, nil
 	}
-	
+
 	limit = strings.ToUpper(strings.TrimSpace(limit))
-	
+
 	var multiplier int64 = 1
 	var numStr string
-	
+
 	switch {
 	case strings.HasSuffix(limit, "T"):
 		multiplier = 1024 * 1024 * 1024 * 1024
@@ -175,31 +175,11 @@ func ParseStorageLimit(limit string) (int64, error) {
 	default:
 		numStr = limit
 	}
-	
+
 	num, err := strconv.ParseFloat(numStr, 64)
 	if err != nil {
 		return 0, fmt.Errorf("invalid storage limit format: %s", limit)
 	}
-	
-	return int64(num * float64(multiplier)), nil
-}
 
-// FormatStorageSize formats bytes to human readable format
-func FormatStorageSize(bytes int64) string {
-	if bytes < 0 {
-		return "unlimited"
-	}
-	
-	const unit = 1024
-	if bytes < unit {
-		return fmt.Sprintf("%d B", bytes)
-	}
-	
-	div, exp := int64(unit), 0
-	for n := bytes / unit; n >= unit; n /= unit {
-		div *= unit
-		exp++
-	}
-	
-	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
+	return int64(num * float64(multiplier)), nil
 }

--- a/pkg/output/formatter.go
+++ b/pkg/output/formatter.go
@@ -108,8 +108,8 @@ func Debug(format string, args ...interface{}) {
 	}
 }
 
-// FormatSize formats bytes into human readable format. A negative value
-// returns "unlimited".
+// FormatSize returns a human readable string for a byte size.
+// Negative values yield "unlimited".
 func FormatSize(bytes int64) string {
 	if bytes < 0 {
 		return "unlimited"

--- a/pkg/output/formatter.go
+++ b/pkg/output/formatter.go
@@ -108,8 +108,13 @@ func Debug(format string, args ...interface{}) {
 	}
 }
 
-// FormatSize formats bytes into human readable format
+// FormatSize formats bytes into human readable format. A negative value
+// returns "unlimited".
 func FormatSize(bytes int64) string {
+	if bytes < 0 {
+		return "unlimited"
+	}
+
 	const unit = 1024
 	if bytes < unit {
 		return fmt.Sprintf("%d B", bytes)

--- a/pkg/output/formatter.go
+++ b/pkg/output/formatter.go
@@ -108,8 +108,9 @@ func Debug(format string, args ...interface{}) {
 	}
 }
 
-// FormatSize returns a human readable string for a byte size.
-// Negative values yield "unlimited".
+// FormatSize converts a byte count to a human readable string.
+// Use this helper throughout the CLI when reporting storage quotas.
+// Negative sizes return "unlimited".
 func FormatSize(bytes int64) string {
 	if bytes < 0 {
 		return "unlimited"


### PR DESCRIPTION
## Summary
- centralize byte-size formatting in pkg/output
- use the shared helper in project commands
- drop obsolete FormatStorageSize implementation

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6847539763d48325ac3995248ccc0957