### PR TITLE
Fix LDFLAGS duplication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,6 @@ GOFILES := $(wildcard *.go)
 # Build targets
 TARGETS := darwin/amd64 darwin/arm64 linux/amd64 linux/arm64 windows/amd64
 
-# Use linker flags to provide version/build settings
-LDFLAGS=-ldflags "-X=${MODULE_NAME}/internal/version.Version=$(VERSION) -X=${MODULE_NAME}/internal/version.BuildTime=$(BUILD_TIME)"
 
 # Default target
 .PHONY: all

--- a/scaffolding/setup_prj.sh
+++ b/scaffolding/setup_prj.sh
@@ -1373,8 +1373,6 @@ GOFILES := $(wildcard *.go)
 # Build targets
 TARGETS := darwin/amd64 darwin/arm64 linux/amd64 linux/arm64 windows/amd64
 
-# Use linker flags to provide version/build settings
-LDFLAGS=-ldflags "-X=${MODULE_NAME}/internal/version.Version=$(VERSION) -X=${MODULE_NAME}/internal/version.BuildTime=$(BUILD_TIME)"
 
 # Default target
 .PHONY: all


### PR DESCRIPTION
## Summary
- remove duplicate LDFLAGS definition from `Makefile`
- remove duplicate LDFLAGS definition from scaffolding script

## Testing
- `make test`
- `make build` *(fails: stat cmd/hrbcli directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68475390824883258cd9b7dd37863c1e