### PR TITLE
Fix missing CLI entry point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ bin/
 *.so
 *.dylib
 hrbcli
+!cmd/hrbcli/
 
 # Test binary, built with `go test -c`
 *.test

--- a/cmd/hrbcli/main.go
+++ b/cmd/hrbcli/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pascal71/hrbcli/cmd"
+)
+
+func main() {
+	if err := cmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## Summary
- expose the `cmd.Execute` errors by adding a proper `main` package
- allow the `cmd/hrbcli` directory to be tracked

## Testing
- `make build`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6847523568608325834711ab9a5c4503