### PR TITLE
Add harbor user management

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -91,8 +91,8 @@ func init() {
 	// Add commands - we'll implement these next
 	rootCmd.AddCommand(NewProjectCmd())
 	rootCmd.AddCommand(NewRegistryCmd())
+	rootCmd.AddCommand(NewUserCmd())
 	// rootCmd.AddCommand(NewRepositoryCmd())
-	// rootCmd.AddCommand(NewUserCmd())
 	// rootCmd.AddCommand(NewSystemCmd())
 	rootCmd.AddCommand(NewConfigCmd())
 	rootCmd.AddCommand(NewVersionCmd())

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -1,0 +1,223 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/manifoldco/promptui"
+	"github.com/spf13/cobra"
+
+	"github.com/pascal71/hrbcli/pkg/api"
+	"github.com/pascal71/hrbcli/pkg/harbor"
+	"github.com/pascal71/hrbcli/pkg/output"
+)
+
+// NewUserCmd creates the user command
+func NewUserCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "user",
+		Short: "Manage Harbor users",
+		Long:  `Manage Harbor users including listing, creation and deletion.`,
+	}
+
+	cmd.AddCommand(newUserListCmd())
+	cmd.AddCommand(newUserCreateCmd())
+	cmd.AddCommand(newUserDeleteCmd())
+
+	return cmd
+}
+
+func newUserListCmd() *cobra.Command {
+	var (
+		search   string
+		page     int
+		pageSize int
+		detail   bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List users",
+		Long:  `List Harbor users.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := api.NewClient()
+			if err != nil {
+				return err
+			}
+
+			userSvc := harbor.NewUserService(client)
+
+			opts := &api.ListOptions{Page: page, PageSize: pageSize}
+			var users []*api.User
+			if search != "" {
+				users, err = userSvc.Search(search, opts)
+			} else {
+				users, err = userSvc.List(opts)
+			}
+			if err != nil {
+				return fmt.Errorf("failed to list users: %w", err)
+			}
+
+			if len(users) == 0 {
+				output.Info("No users found")
+				return nil
+			}
+
+			switch output.GetFormat() {
+			case "json":
+				return output.JSON(users)
+			case "yaml":
+				return output.YAML(users)
+			default:
+				table := output.Table()
+				headers := []string{"ID", "USERNAME", "EMAIL", "ADMIN", "CREATED"}
+				if detail {
+					headers = append(headers, "REALNAME")
+				}
+				table.Append(headers)
+
+				for _, u := range users {
+					row := []string{
+						strconv.Itoa(u.UserID),
+						u.Username,
+						u.Email,
+						strconv.FormatBool(u.SysadminFlag),
+						u.CreationTime.Format("2006-01-02"),
+					}
+					if detail {
+						row = append(row, u.Realname)
+					}
+					table.Append(row)
+				}
+
+				table.Render()
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&search, "search", "", "Search by username")
+	cmd.Flags().IntVar(&page, "page", 1, "Page number")
+	cmd.Flags().IntVar(&pageSize, "page-size", 20, "Page size")
+	cmd.Flags().BoolVar(&detail, "detail", false, "Show detailed information")
+
+	return cmd
+}
+
+func newUserCreateCmd() *cobra.Command {
+	var (
+		email    string
+		realname string
+		password string
+		admin    bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create <username>",
+		Short: "Create a new user",
+		Long:  `Create a new Harbor user.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			username := args[0]
+
+			if password == "" {
+				prompt := promptui.Prompt{Label: "Password", Mask: '*'}
+				p, err := prompt.Run()
+				if err != nil {
+					return err
+				}
+				password = p
+			}
+
+			client, err := api.NewClient()
+			if err != nil {
+				return err
+			}
+
+			userSvc := harbor.NewUserService(client)
+
+			req := &api.UserReq{
+				Username: username,
+				Email:    email,
+				Password: password,
+				Realname: realname,
+			}
+
+			user, err := userSvc.Create(req)
+			if err != nil {
+				return fmt.Errorf("failed to create user: %w", err)
+			}
+
+			if admin && user != nil {
+				if err := userSvc.SetAdmin(int64(user.UserID), true); err != nil {
+					output.Warning("Failed to set admin flag: %v", err)
+				}
+				user.SysadminFlag = true
+			}
+
+			output.Success("User '%s' created", username)
+			if output.GetFormat() == "table" && user != nil {
+				output.Info("")
+				fmt.Printf("ID:        %d\n", user.UserID)
+				fmt.Printf("Username:  %s\n", user.Username)
+				fmt.Printf("Admin:     %v\n", user.SysadminFlag)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&email, "email", "", "Email address")
+	cmd.Flags().StringVar(&realname, "realname", "", "Real name")
+	cmd.Flags().StringVar(&password, "password", "", "User password")
+	cmd.Flags().BoolVar(&admin, "admin", false, "Create as Harbor admin")
+
+	return cmd
+}
+
+func newUserDeleteCmd() *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "delete <username>",
+		Short: "Delete a user",
+		Long:  `Delete a Harbor user by username.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			username := args[0]
+
+			client, err := api.NewClient()
+			if err != nil {
+				return err
+			}
+
+			userSvc := harbor.NewUserService(client)
+
+			user, err := userSvc.GetByUsername(username)
+			if err != nil {
+				return err
+			}
+
+			if !force {
+				prompt := promptui.Prompt{Label: fmt.Sprintf("Delete user '%s'", username), IsConfirm: true}
+				result, err := prompt.Run()
+				if err != nil || strings.ToLower(result) != "y" {
+					output.Info("Deletion cancelled")
+					return nil
+				}
+			}
+
+			if err := userSvc.Delete(int64(user.UserID)); err != nil {
+				return fmt.Errorf("failed to delete user: %w", err)
+			}
+
+			output.Success("User '%s' deleted", username)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Force deletion without confirmation")
+	return cmd
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -6,18 +6,18 @@ import (
 
 // Project represents a Harbor project
 type Project struct {
-	ProjectID    int64     `json:"project_id"`
-	Name         string    `json:"name"`
-	Public       bool      `json:"public"`
-	OwnerID      int       `json:"owner_id"`
-	OwnerName    string    `json:"owner_name"`
-	CreationTime time.Time `json:"creation_time"`
-	UpdateTime   time.Time `json:"update_time"`
-	Deleted      bool      `json:"deleted"`
-	RepoCount    int64     `json:"repo_count"`
+	ProjectID    int64            `json:"project_id"`
+	Name         string           `json:"name"`
+	Public       bool             `json:"public"`
+	OwnerID      int              `json:"owner_id"`
+	OwnerName    string           `json:"owner_name"`
+	CreationTime time.Time        `json:"creation_time"`
+	UpdateTime   time.Time        `json:"update_time"`
+	Deleted      bool             `json:"deleted"`
+	RepoCount    int64            `json:"repo_count"`
 	Metadata     *ProjectMetadata `json:"metadata,omitempty"`
-	CVEAllowlist *CVEAllowlist   `json:"cve_allowlist,omitempty"`
-	StorageLimit int64     `json:"storage_limit,omitempty"`
+	CVEAllowlist *CVEAllowlist    `json:"cve_allowlist,omitempty"`
+	StorageLimit int64            `json:"storage_limit,omitempty"`
 }
 
 // ProjectReq represents a project creation/update request
@@ -25,10 +25,10 @@ type ProjectReq struct {
 	ProjectName  string           `json:"project_name"`
 	Public       *bool            `json:"public,omitempty"`
 	Metadata     *ProjectMetadata `json:"metadata,omitempty"`
-	CVEAllowlist *CVEAllowlist   `json:"cve_allowlist,omitempty"`
-	StorageLimit *int64          `json:"storage_limit,omitempty"`
-	CountLimit   *int64          `json:"count_limit,omitempty"`
-	RegistryID   *int64          `json:"registry_id,omitempty"`
+	CVEAllowlist *CVEAllowlist    `json:"cve_allowlist,omitempty"`
+	StorageLimit *int64           `json:"storage_limit,omitempty"`
+	CountLimit   *int64           `json:"count_limit,omitempty"`
+	RegistryID   *int64           `json:"registry_id,omitempty"`
 }
 
 // ProjectMetadata represents project metadata
@@ -45,11 +45,11 @@ type ProjectMetadata struct {
 
 // CVEAllowlist represents a CVE allowlist
 type CVEAllowlist struct {
-	ID           int64             `json:"id,omitempty"`
-	ProjectID    int64             `json:"project_id,omitempty"`
+	ID           int64              `json:"id,omitempty"`
+	ProjectID    int64              `json:"project_id,omitempty"`
 	Items        []CVEAllowlistItem `json:"items,omitempty"`
-	CreationTime time.Time         `json:"creation_time,omitempty"`
-	UpdateTime   time.Time         `json:"update_time,omitempty"`
+	CreationTime time.Time          `json:"creation_time,omitempty"`
+	UpdateTime   time.Time          `json:"update_time,omitempty"`
 }
 
 // CVEAllowlistItem represents a CVE allowlist item
@@ -59,19 +59,19 @@ type CVEAllowlistItem struct {
 
 // ProjectSummary represents project summary information
 type ProjectSummary struct {
-	RepoCount     int64          `json:"repo_count"`
-	ProjectAdminCount int64      `json:"project_admin_count"`
-	MasterCount   int64          `json:"master_count"`
-	DeveloperCount int64         `json:"developer_count"`
-	GuestCount    int64          `json:"guest_count"`
-	LimitedGuestCount int64      `json:"limited_guest_count"`
-	Quota         *ProjectQuota  `json:"quota,omitempty"`
+	RepoCount         int64         `json:"repo_count"`
+	ProjectAdminCount int64         `json:"project_admin_count"`
+	MasterCount       int64         `json:"master_count"`
+	DeveloperCount    int64         `json:"developer_count"`
+	GuestCount        int64         `json:"guest_count"`
+	LimitedGuestCount int64         `json:"limited_guest_count"`
+	Quota             *ProjectQuota `json:"quota,omitempty"`
 }
 
 // ProjectQuota represents project quota information
 type ProjectQuota struct {
-	Hard QuotaHard     `json:"hard"`
-	Used QuotaUsed     `json:"used"`
+	Hard QuotaHard `json:"hard"`
+	Used QuotaUsed `json:"used"`
 }
 
 // QuotaHard represents hard quota limits
@@ -88,30 +88,51 @@ type QuotaUsed struct {
 
 // User represents a Harbor user
 type User struct {
-	UserID       int       `json:"user_id"`
-	Username     string    `json:"username"`
-	Email        string    `json:"email"`
-	Password     string    `json:"password,omitempty"`
-	Realname     string    `json:"realname"`
-	Comment      string    `json:"comment"`
-	Deleted      bool      `json:"deleted"`
-	AdminRoleInAuth bool   `json:"admin_role_in_auth"`
-	SysadminFlag bool      `json:"sysadmin_flag"`
-	CreationTime time.Time `json:"creation_time"`
-	UpdateTime   time.Time `json:"update_time"`
+	UserID          int       `json:"user_id"`
+	Username        string    `json:"username"`
+	Email           string    `json:"email"`
+	Password        string    `json:"password,omitempty"`
+	Realname        string    `json:"realname"`
+	Comment         string    `json:"comment"`
+	Deleted         bool      `json:"deleted"`
+	AdminRoleInAuth bool      `json:"admin_role_in_auth"`
+	SysadminFlag    bool      `json:"sysadmin_flag"`
+	CreationTime    time.Time `json:"creation_time"`
+	UpdateTime      time.Time `json:"update_time"`
+}
+
+// UserReq represents a request to create or update a user
+type UserReq struct {
+	Username string `json:"username"`
+	Email    string `json:"email"`
+	Password string `json:"password,omitempty"`
+	Realname string `json:"realname,omitempty"`
+	Comment  string `json:"comment,omitempty"`
+}
+
+// UserProfile represents a user profile update
+type UserProfile struct {
+	Email    string `json:"email"`
+	Realname string `json:"realname"`
+	Comment  string `json:"comment"`
+}
+
+// SysAdminFlag is used to set or unset Harbor admin privilege
+type SysAdminFlag struct {
+	SysadminFlag bool `json:"sysadmin_flag"`
 }
 
 // SystemInfo represents Harbor system information
 type SystemInfo struct {
-	HarborVersion     string `json:"harbor_version"`
-	RegistryURL       string `json:"registry_url"`
-	ExternalURL       string `json:"external_url"`
-	AuthMode          string `json:"auth_mode"`
-	ProjectCreationRestriction string `json:"project_creation_restriction"`
-	SelfRegistration  bool   `json:"self_registration"`
-	HasCARoot         bool   `json:"has_ca_root"`
-	WithNotary        bool   `json:"with_notary"`
-	WithChartmuseum   bool   `json:"with_chartmuseum"`
+	HarborVersion               string `json:"harbor_version"`
+	RegistryURL                 string `json:"registry_url"`
+	ExternalURL                 string `json:"external_url"`
+	AuthMode                    string `json:"auth_mode"`
+	ProjectCreationRestriction  string `json:"project_creation_restriction"`
+	SelfRegistration            bool   `json:"self_registration"`
+	HasCARoot                   bool   `json:"has_ca_root"`
+	WithNotary                  bool   `json:"with_notary"`
+	WithChartmuseum             bool   `json:"with_chartmuseum"`
 	RegistryStorageProviderName string `json:"registry_storage_provider_name"`
 }
 

--- a/pkg/harbor/user.go
+++ b/pkg/harbor/user.go
@@ -1,0 +1,155 @@
+package harbor
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/pascal71/hrbcli/pkg/api"
+)
+
+// UserService handles user-related operations
+type UserService struct {
+	client *api.Client
+}
+
+// NewUserService creates a new user service
+func NewUserService(client *api.Client) *UserService {
+	return &UserService{client: client}
+}
+
+// List lists users
+func (s *UserService) List(opts *api.ListOptions) ([]*api.User, error) {
+	params := make(map[string]string)
+	if opts != nil {
+		if opts.Page > 0 {
+			params["page"] = strconv.Itoa(opts.Page)
+		}
+		if opts.PageSize > 0 {
+			params["page_size"] = strconv.Itoa(opts.PageSize)
+		}
+		if opts.Query != "" {
+			params["q"] = opts.Query
+		}
+		if opts.Sort != "" {
+			params["sort"] = opts.Sort
+		}
+	}
+	resp, err := s.client.Get("/users", params)
+	if err != nil {
+		return nil, err
+	}
+	var users []*api.User
+	if err := s.client.DecodeResponse(resp, &users); err != nil {
+		return nil, fmt.Errorf("failed to decode users: %w", err)
+	}
+	return users, nil
+}
+
+// Search searches users by username
+func (s *UserService) Search(username string, opts *api.ListOptions) ([]*api.User, error) {
+	params := map[string]string{"username": username}
+	if opts != nil {
+		if opts.Page > 0 {
+			params["page"] = strconv.Itoa(opts.Page)
+		}
+		if opts.PageSize > 0 {
+			params["page_size"] = strconv.Itoa(opts.PageSize)
+		}
+	}
+	resp, err := s.client.Get("/users/search", params)
+	if err != nil {
+		return nil, err
+	}
+	var users []*api.User
+	if err := s.client.DecodeResponse(resp, &users); err != nil {
+		return nil, fmt.Errorf("failed to decode users: %w", err)
+	}
+	return users, nil
+}
+
+// Get retrieves a user by ID
+func (s *UserService) Get(id int64) (*api.User, error) {
+	resp, err := s.client.Get(fmt.Sprintf("/users/%d", id), nil)
+	if err != nil {
+		return nil, err
+	}
+	var user api.User
+	if err := s.client.DecodeResponse(resp, &user); err != nil {
+		return nil, fmt.Errorf("failed to decode user: %w", err)
+	}
+	return &user, nil
+}
+
+// GetByUsername fetches a user by username
+func (s *UserService) GetByUsername(username string) (*api.User, error) {
+	users, err := s.Search(username, nil)
+	if err != nil {
+		return nil, err
+	}
+	for _, u := range users {
+		if u.Username == username {
+			return s.Get(int64(u.UserID))
+		}
+	}
+	return nil, fmt.Errorf("user '%s' not found", username)
+}
+
+// Create creates a new user
+func (s *UserService) Create(req *api.UserReq) (*api.User, error) {
+	resp, err := s.client.Post("/users", req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+	location := resp.Header.Get("Location")
+	if location == "" {
+		return nil, nil
+	}
+	var id int64
+	fmt.Sscanf(location, "/api/%*s/users/%d", &id)
+	return s.Get(id)
+}
+
+// Delete deletes a user by ID
+func (s *UserService) Delete(id int64) error {
+	resp, err := s.client.Delete(fmt.Sprintf("/users/%d", id))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// SetAdmin toggles admin role for a user
+func (s *UserService) SetAdmin(id int64, admin bool) error {
+	flag := &api.SysAdminFlag{SysadminFlag: admin}
+	resp, err := s.client.Put(fmt.Sprintf("/users/%d/sysadmin", id), flag)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// UpdateProfile updates user's profile fields
+func (s *UserService) UpdateProfile(id int64, profile *api.UserProfile) error {
+	resp, err := s.client.Put(fmt.Sprintf("/users/%d", id), profile)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add `UserService` with CRUD operations for Harbor users
- implement `user` command with list/create/delete subcommands
- enable user command in root command
- define user request/flag structs in API types

## Testing
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68475dc00b808325b3336d0ac6cb5dd8