### PR TITLE
Add artifact report commands

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -155,6 +155,26 @@ hrbcli artifact scan myproject/myapp@sha256:abc123
 hrbcli artifact scan myproject/myapp --all
 ```
 
+#### `hrbcli artifact vulnerabilities`
+
+Show vulnerability report for an artifact. Use `--severity` to fail if vulnerabilities of that level or higher exist.
+
+```bash
+# Show vulnerabilities
+hrbcli artifact vulnerabilities myproject/myapp:latest
+
+# Fail if high or critical vulns found
+hrbcli artifact vulnerabilities myproject/myapp:latest --severity high
+```
+
+#### `hrbcli artifact sbom`
+
+Display the SBOM report for an artifact.
+
+```bash
+hrbcli artifact sbom myproject/myapp:latest -o json
+```
+
 #### `hrbcli artifact copy`
 
 Copy artifacts between projects.

--- a/pkg/api/scanner_types.go
+++ b/pkg/api/scanner_types.go
@@ -1,0 +1,17 @@
+package api
+
+// VulnerabilityReport represents a vulnerability scanning report
+// Only fields needed by the CLI are included.
+type VulnerabilityReport struct {
+	Vulnerabilities []VulnerabilityItem `json:"vulnerabilities"`
+}
+
+// VulnerabilityItem represents a single vulnerability entry
+// returned by Harbor scanners.
+type VulnerabilityItem struct {
+	CVEID        string `json:"id"`
+	Package      string `json:"package"`
+	Version      string `json:"version"`
+	FixedVersion string `json:"fix_version"`
+	Severity     string `json:"severity"`
+}

--- a/pkg/harbor/artifact.go
+++ b/pkg/harbor/artifact.go
@@ -38,3 +38,37 @@ func (s *ArtifactService) Scan(project, repository, reference string, scanType s
 
 	return nil
 }
+
+// Vulnerabilities retrieves the vulnerability report for the specified artifact
+func (s *ArtifactService) Vulnerabilities(project, repository, reference string) (*api.VulnerabilityReport, error) {
+	path := fmt.Sprintf("/projects/%s/repositories/%s/artifacts/%s/additions/vulnerabilities", project, repository, reference)
+
+	resp, err := s.client.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var report api.VulnerabilityReport
+	if err := s.client.DecodeResponse(resp, &report); err != nil {
+		return nil, fmt.Errorf("failed to decode vulnerability report: %w", err)
+	}
+
+	return &report, nil
+}
+
+// SBOM retrieves the SBOM report for the specified artifact
+func (s *ArtifactService) SBOM(project, repository, reference string) (map[string]interface{}, error) {
+	path := fmt.Sprintf("/projects/%s/repositories/%s/artifacts/%s/additions/sbom", project, repository, reference)
+
+	resp, err := s.client.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var report map[string]interface{}
+	if err := s.client.DecodeResponse(resp, &report); err != nil {
+		return nil, fmt.Errorf("failed to decode SBOM: %w", err)
+	}
+
+	return report, nil
+}


### PR DESCRIPTION
## Summary
- implement `artifact vulnerabilities` and `artifact sbom` commands
- add types and service helpers to fetch vulnerability/SBOM data
- document new commands

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_684762160cc48325a783bd21db3623a5