### PR TITLE
Add system statistics command

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ hrbcli repo delete myproject/myapp:v1.0.0
 
 # Get system information
 hrbcli system info
+
+# Show Harbor statistics
+hrbcli system statistics
 ```
 
 ## Configuration

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -96,7 +96,7 @@ func init() {
 	// rootCmd.AddCommand(NewRepositoryCmd())
 	rootCmd.AddCommand(NewRepositoryCmd())
 	// rootCmd.AddCommand(NewUserCmd())
-	// rootCmd.AddCommand(NewSystemCmd())
+	rootCmd.AddCommand(NewSystemCmd())
 	rootCmd.AddCommand(NewConfigCmd())
 	rootCmd.AddCommand(NewVersionCmd())
 	rootCmd.AddCommand(NewCompletionCmd())

--- a/cmd/system.go
+++ b/cmd/system.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pascal71/hrbcli/pkg/api"
+	"github.com/pascal71/hrbcli/pkg/harbor"
+	"github.com/pascal71/hrbcli/pkg/output"
+)
+
+// NewSystemCmd creates the system command
+func NewSystemCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "system",
+		Short: "System administration commands",
+		Long:  `Manage Harbor system operations`,
+	}
+
+	cmd.AddCommand(newSystemStatisticsCmd())
+
+	return cmd
+}
+
+func newSystemStatisticsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "statistics",
+		Short: "Show Harbor statistics",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := api.NewClient()
+			if err != nil {
+				return err
+			}
+
+			sysSvc := harbor.NewSystemService(client)
+
+			stats, err := sysSvc.GetStatistics()
+			if err != nil {
+				return fmt.Errorf("failed to get statistics: %w", err)
+			}
+
+			switch output.GetFormat() {
+			case "json":
+				return output.JSON(stats)
+			case "yaml":
+				return output.YAML(stats)
+			default:
+				table := output.Table()
+				table.Append([]string{"PRIVATE PROJECTS", "PUBLIC PROJECTS", "TOTAL PROJECTS", "PRIVATE REPOS", "PUBLIC REPOS", "TOTAL REPOS", "STORAGE"})
+				table.Append([]string{
+					strconv.FormatInt(stats.PrivateProjectCount, 10),
+					strconv.FormatInt(stats.PublicProjectCount, 10),
+					strconv.FormatInt(stats.TotalProjectCount, 10),
+					strconv.FormatInt(stats.PrivateRepoCount, 10),
+					strconv.FormatInt(stats.PublicRepoCount, 10),
+					strconv.FormatInt(stats.TotalRepoCount, 10),
+					harbor.FormatStorageSize(stats.TotalStorageConsumption),
+				})
+				table.Render()
+				return nil
+			}
+		},
+	}
+
+	return cmd
+}

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -228,6 +228,18 @@ hrbcli system info --with-storage
 hrbcli system info -o yaml
 ```
 
+#### `hrbcli system statistics`
+
+Show general Harbor statistics.
+
+```bash
+# Display statistics
+hrbcli system statistics
+
+# Output as JSON
+hrbcli system statistics -o json
+```
+
 #### `hrbcli system health`
 
 Check system health.

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -99,7 +99,6 @@ type User struct {
 	SysadminFlag    bool      `json:"sysadmin_flag"`
 	CreationTime    time.Time `json:"creation_time"`
 	UpdateTime      time.Time `json:"update_time"`
-
 }
 
 // UserReq represents a request to create or update a user
@@ -121,7 +120,6 @@ type UserProfile struct {
 // SysAdminFlag is used to set or unset Harbor admin privilege
 type SysAdminFlag struct {
 	SysadminFlag bool `json:"sysadmin_flag"`
-
 }
 
 // SystemInfo represents Harbor system information
@@ -136,6 +134,17 @@ type SystemInfo struct {
 	WithNotary                  bool   `json:"with_notary"`
 	WithChartmuseum             bool   `json:"with_chartmuseum"`
 	RegistryStorageProviderName string `json:"registry_storage_provider_name"`
+}
+
+// Statistic represents Harbor statistics information
+type Statistic struct {
+	PrivateProjectCount     int64 `json:"private_project_count"`
+	PrivateRepoCount        int64 `json:"private_repo_count"`
+	PublicProjectCount      int64 `json:"public_project_count"`
+	PublicRepoCount         int64 `json:"public_repo_count"`
+	TotalProjectCount       int64 `json:"total_project_count"`
+	TotalRepoCount          int64 `json:"total_repo_count"`
+	TotalStorageConsumption int64 `json:"total_storage_consumption"`
 }
 
 // Pagination represents pagination information

--- a/pkg/harbor/system.go
+++ b/pkg/harbor/system.go
@@ -1,0 +1,32 @@
+package harbor
+
+import (
+	"fmt"
+
+	"github.com/pascal71/hrbcli/pkg/api"
+)
+
+// SystemService handles system related operations
+type SystemService struct {
+	client *api.Client
+}
+
+// NewSystemService creates a new SystemService
+func NewSystemService(client *api.Client) *SystemService {
+	return &SystemService{client: client}
+}
+
+// GetStatistics retrieves Harbor statistics
+func (s *SystemService) GetStatistics() (*api.Statistic, error) {
+	resp, err := s.client.Get("/statistics", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var stats api.Statistic
+	if err := s.client.DecodeResponse(resp, &stats); err != nil {
+		return nil, fmt.Errorf("failed to decode statistics: %w", err)
+	}
+
+	return &stats, nil
+}


### PR DESCRIPTION
## Summary
- implement API types and service for Harbor statistics
- add `system statistics` command
- update root command list
- document new command
- mention in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6847623594208325aa5042a1f35738e5