### PR TITLE
Escape artifact API paths

### DIFF
--- a/cmd/system.go
+++ b/cmd/system.go
@@ -2,23 +2,17 @@ package cmd
 
 import (
 	"fmt"
-
 	"io"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
-
-	"github.com/spf13/cobra"
-
-
 	"strconv"
 
 	"github.com/spf13/cobra"
 
 	"github.com/pascal71/hrbcli/pkg/api"
 	"github.com/pascal71/hrbcli/pkg/harbor"
-
 	"github.com/pascal71/hrbcli/pkg/output"
 )
 
@@ -26,22 +20,15 @@ import (
 func NewSystemCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "system",
-		Short: "System administration tasks",
-		Long:  `Manage Harbor system level tasks like backups and maintenance.`,
-	}
-
-	cmd.AddCommand(newSystemBackupCmd())
-
 		Short: "System administration commands",
 		Long:  `Manage Harbor system operations`,
 	}
 
+	cmd.AddCommand(newSystemBackupCmd())
 	cmd.AddCommand(newSystemStatisticsCmd())
-
 
 	return cmd
 }
-
 
 func newSystemBackupCmd() *cobra.Command {
 	var outputDir string
@@ -50,7 +37,7 @@ func newSystemBackupCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "backup",
 		Short: "Backup Harbor data",
-		Long: `Create a backup of Harbor's database and storage using the community backup script. 
+		Long: `Create a backup of Harbor's database and storage using the community backup script.
 Docker must be installed and the command should be executed on the Harbor host.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if outputDir == "" {
@@ -104,6 +91,8 @@ Docker must be installed and the command should be executed on the Harbor host.`
 	cmd.Flags().StringVar(&outputDir, "dir", ".", "Directory to store the backup archive")
 	cmd.Flags().BoolVar(&dbOnly, "db-only", false, "Backup database only")
 
+	return cmd
+}
 
 func newSystemStatisticsCmd() *cobra.Command {
 	cmd := &cobra.Command{

--- a/pkg/harbor/artifact.go
+++ b/pkg/harbor/artifact.go
@@ -3,6 +3,7 @@ package harbor
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/pascal71/hrbcli/pkg/api"
 )
@@ -19,7 +20,10 @@ func NewArtifactService(client *api.Client) *ArtifactService {
 
 // Scan triggers vulnerability scan for the specified artifact
 func (s *ArtifactService) Scan(project, repository, reference string, scanType string) error {
-	path := fmt.Sprintf("/projects/%s/repositories/%s/artifacts/%s/scan", project, repository, reference)
+	projectEsc := url.PathEscape(project)
+	repoEsc := url.PathEscape(repository)
+	refEsc := url.PathEscape(reference)
+	path := fmt.Sprintf("/projects/%s/repositories/%s/artifacts/%s/scan", projectEsc, repoEsc, refEsc)
 
 	var body interface{}
 	if scanType != "" {
@@ -41,7 +45,10 @@ func (s *ArtifactService) Scan(project, repository, reference string, scanType s
 
 // Vulnerabilities retrieves the vulnerability report for the specified artifact
 func (s *ArtifactService) Vulnerabilities(project, repository, reference string) (*api.VulnerabilityReport, error) {
-	path := fmt.Sprintf("/projects/%s/repositories/%s/artifacts/%s/additions/vulnerabilities", project, repository, reference)
+	projectEsc := url.PathEscape(project)
+	repoEsc := url.PathEscape(repository)
+	refEsc := url.PathEscape(reference)
+	path := fmt.Sprintf("/projects/%s/repositories/%s/artifacts/%s/additions/vulnerabilities", projectEsc, repoEsc, refEsc)
 
 	resp, err := s.client.Get(path, nil)
 	if err != nil {
@@ -58,7 +65,10 @@ func (s *ArtifactService) Vulnerabilities(project, repository, reference string)
 
 // SBOM retrieves the SBOM report for the specified artifact
 func (s *ArtifactService) SBOM(project, repository, reference string) (map[string]interface{}, error) {
-	path := fmt.Sprintf("/projects/%s/repositories/%s/artifacts/%s/additions/sbom", project, repository, reference)
+	projectEsc := url.PathEscape(project)
+	repoEsc := url.PathEscape(repository)
+	refEsc := url.PathEscape(reference)
+	path := fmt.Sprintf("/projects/%s/repositories/%s/artifacts/%s/additions/sbom", projectEsc, repoEsc, refEsc)
 
 	resp, err := s.client.Get(path, nil)
 	if err != nil {


### PR DESCRIPTION
## Summary
- escape project, repository and reference when calling artifact APIs
- clean up `system.go` to fix build errors

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6847677544c083259e3b7ab1fc795147