### PR TITLE
Add replication management commands

### DIFF
--- a/cmd/replication.go
+++ b/cmd/replication.go
@@ -1,0 +1,336 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pascal71/hrbcli/pkg/api"
+	"github.com/pascal71/hrbcli/pkg/harbor"
+	"github.com/pascal71/hrbcli/pkg/output"
+)
+
+// NewReplicationCmd creates the replication command
+func NewReplicationCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "replication",
+		Short: "Manage replication policies",
+	}
+
+	cmd.AddCommand(newReplicationListCmd())
+	cmd.AddCommand(newReplicationCreateCmd())
+	cmd.AddCommand(newReplicationGetCmd())
+	cmd.AddCommand(newReplicationDeleteCmd())
+	cmd.AddCommand(newReplicationExecuteCmd())
+	cmd.AddCommand(newReplicationExecutionsCmd())
+	cmd.AddCommand(newReplicationExecutionCmd())
+	cmd.AddCommand(newReplicationLogsCmd())
+	cmd.AddCommand(newReplicationStatsCmd())
+
+	return cmd
+}
+
+func newReplicationListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List replication policies",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := api.NewClient()
+			if err != nil {
+				return err
+			}
+			svc := harbor.NewReplicationService(client)
+			policies, err := svc.ListPolicies(nil)
+			if err != nil {
+				return err
+			}
+
+			switch output.GetFormat() {
+			case "json":
+				return output.JSON(policies)
+			case "yaml":
+				return output.YAML(policies)
+			default:
+				table := output.Table()
+				table.Append([]string{"ID", "NAME", "ENABLED"})
+				for _, p := range policies {
+					table.Append([]string{
+						strconv.FormatInt(p.ID, 10),
+						p.Name,
+						strconv.FormatBool(p.Enabled),
+					})
+				}
+				table.Render()
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newReplicationGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Show replication policy",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid id: %w", err)
+			}
+			client, err := api.NewClient()
+			if err != nil {
+				return err
+			}
+			svc := harbor.NewReplicationService(client)
+			policy, err := svc.GetPolicy(id)
+			if err != nil {
+				return err
+			}
+			switch output.GetFormat() {
+			case "json":
+				return output.JSON(policy)
+			case "yaml":
+				return output.YAML(policy)
+			default:
+				table := output.Table()
+				table.Append([]string{"FIELD", "VALUE"})
+				table.Append([]string{"ID", strconv.FormatInt(policy.ID, 10)})
+				table.Append([]string{"NAME", policy.Name})
+				table.Append([]string{"ENABLED", strconv.FormatBool(policy.Enabled)})
+				table.Render()
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newReplicationCreateCmd() *cobra.Command {
+	var src, dst, name string
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create replication policy",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if name == "" || src == "" || dst == "" {
+				return fmt.Errorf("--name, --source and --destination are required")
+			}
+			client, err := api.NewClient()
+			if err != nil {
+				return err
+			}
+			svc := harbor.NewReplicationService(client)
+			req := &api.ReplicationPolicy{Name: name, SrcRegistry: &api.Registry{Name: src}, DestRegistry: &api.Registry{Name: dst}, Enabled: true}
+			policy, err := svc.CreatePolicy(req)
+			if err != nil {
+				return err
+			}
+			output.Success("Created replication policy %s (ID %d)", policy.Name, policy.ID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&name, "name", "", "Policy name")
+	cmd.Flags().StringVar(&src, "source", "", "Source registry")
+	cmd.Flags().StringVar(&dst, "destination", "", "Destination registry")
+	return cmd
+}
+
+func newReplicationDeleteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete replication policy",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid id: %w", err)
+			}
+			client, err := api.NewClient()
+			if err != nil {
+				return err
+			}
+			svc := harbor.NewReplicationService(client)
+			if err := svc.DeletePolicy(id); err != nil {
+				return err
+			}
+			output.Success("Deleted replication policy %d", id)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newReplicationExecuteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "execute <policy-id>",
+		Short: "Trigger replication execution",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid id: %w", err)
+			}
+			client, err := api.NewClient()
+			if err != nil {
+				return err
+			}
+			svc := harbor.NewReplicationService(client)
+			exec, err := svc.StartExecution(id)
+			if err != nil {
+				return err
+			}
+			output.Success("Started execution %d", exec.ID)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newReplicationExecutionsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "executions [policy-id]",
+		Short: "List replication executions",
+		Args:  cobra.RangeArgs(0, 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var id int64
+			var err error
+			if len(args) == 1 {
+				id, err = strconv.ParseInt(args[0], 10, 64)
+				if err != nil {
+					return fmt.Errorf("invalid id: %w", err)
+				}
+			}
+			client, err := api.NewClient()
+			if err != nil {
+				return err
+			}
+			svc := harbor.NewReplicationService(client)
+			execs, err := svc.ListExecutions(id)
+			if err != nil {
+				return err
+			}
+			switch output.GetFormat() {
+			case "json":
+				return output.JSON(execs)
+			case "yaml":
+				return output.YAML(execs)
+			default:
+				table := output.Table()
+				table.Append([]string{"ID", "POLICY", "STATUS", "START", "END"})
+				for _, e := range execs {
+					table.Append([]string{
+						strconv.FormatInt(e.ID, 10),
+						strconv.FormatInt(e.PolicyID, 10),
+						e.Status,
+						e.StartTime.Format("2006-01-02 15:04"),
+						e.EndTime.Format("2006-01-02 15:04"),
+					})
+				}
+				table.Render()
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newReplicationExecutionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "execution <id>",
+		Short: "Show execution details",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid id: %w", err)
+			}
+			client, err := api.NewClient()
+			if err != nil {
+				return err
+			}
+			svc := harbor.NewReplicationService(client)
+			exec, err := svc.GetExecution(id)
+			if err != nil {
+				return err
+			}
+			switch output.GetFormat() {
+			case "json":
+				return output.JSON(exec)
+			case "yaml":
+				return output.YAML(exec)
+			default:
+				table := output.Table()
+				table.Append([]string{"FIELD", "VALUE"})
+				table.Append([]string{"STATUS", exec.Status})
+				table.Append([]string{"SUCCEED", strconv.Itoa(exec.Succeed)})
+				table.Append([]string{"FAILED", strconv.Itoa(exec.Failed)})
+				table.Append([]string{"IN_PROGRESS", strconv.Itoa(exec.InProgress)})
+				table.Append([]string{"STOPPED", strconv.Itoa(exec.Stopped)})
+				table.Render()
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newReplicationLogsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "logs <execution-id>",
+		Short: "Show execution logs",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid id: %w", err)
+			}
+			client, err := api.NewClient()
+			if err != nil {
+				return err
+			}
+			svc := harbor.NewReplicationService(client)
+			tasks, err := svc.ListTasks(id)
+			if err != nil {
+				return err
+			}
+			for _, t := range tasks {
+				log, err := svc.GetTaskLog(id, t.ID)
+				if err != nil {
+					return err
+				}
+				output.Info("Task %d", t.ID)
+				fmt.Println(log)
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newReplicationStatsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "statistics",
+		Short: "Show replication statistics",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := api.NewClient()
+			if err != nil {
+				return err
+			}
+			svc := harbor.NewReplicationService(client)
+			execs, err := svc.ListExecutions(0)
+			if err != nil {
+				return err
+			}
+			var succeed, failed, running int
+			for _, e := range execs {
+				succeed += e.Succeed
+				failed += e.Failed
+				running += e.InProgress
+			}
+			fmt.Printf("Succeeded: %d\nFailed: %d\nRunning: %d\n", succeed, failed, running)
+			return nil
+		},
+	}
+	return cmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -95,6 +95,7 @@ func init() {
 	rootCmd.AddCommand(NewUserCmd())
 	// rootCmd.AddCommand(NewRepositoryCmd())
 	rootCmd.AddCommand(NewRepositoryCmd())
+	rootCmd.AddCommand(NewReplicationCmd())
 	// rootCmd.AddCommand(NewUserCmd())
 	rootCmd.AddCommand(NewSystemCmd())
 	rootCmd.AddCommand(NewConfigCmd())

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -332,6 +332,54 @@ hrbcli replication create prod-pull \
   --direction pull
 ```
 
+#### `hrbcli replication get`
+
+Show details of a replication policy.
+
+```bash
+hrbcli replication get 1
+```
+
+#### `hrbcli replication delete`
+
+Delete a replication policy.
+
+```bash
+hrbcli replication delete 1
+```
+
+#### `hrbcli replication executions`
+
+List executions of a policy.
+
+```bash
+hrbcli replication executions 1
+```
+
+#### `hrbcli replication execution`
+
+Show execution statistics.
+
+```bash
+hrbcli replication execution 10
+```
+
+#### `hrbcli replication logs`
+
+Show logs for an execution.
+
+```bash
+hrbcli replication logs 10
+```
+
+#### `hrbcli replication statistics`
+
+Aggregate statistics across executions.
+
+```bash
+hrbcli replication statistics
+```
+
 #### `hrbcli replication execute`
 
 Execute replication manually.

--- a/pkg/api/replication_types.go
+++ b/pkg/api/replication_types.go
@@ -1,0 +1,74 @@
+package api
+
+import "time"
+
+// ReplicationPolicy represents a replication policy
+// Only fields used by the CLI are included
+type ReplicationPolicy struct {
+	ID                int64               `json:"id"`
+	Name              string              `json:"name"`
+	Description       string              `json:"description,omitempty"`
+	SrcRegistry       *Registry           `json:"src_registry,omitempty"`
+	DestRegistry      *Registry           `json:"dest_registry,omitempty"`
+	DestNamespace     string              `json:"dest_namespace,omitempty"`
+	Trigger           *ReplicationTrigger `json:"trigger,omitempty"`
+	Filters           []ReplicationFilter `json:"filters,omitempty"`
+	ReplicateDeletion bool                `json:"replicate_deletion,omitempty"`
+	Override          bool                `json:"override"`
+	Enabled           bool                `json:"enabled"`
+	CreationTime      time.Time           `json:"creation_time,omitempty"`
+	UpdateTime        time.Time           `json:"update_time,omitempty"`
+}
+
+// ReplicationTrigger represents policy trigger
+type ReplicationTrigger struct {
+	Type            string                      `json:"type"`
+	TriggerSettings *ReplicationTriggerSettings `json:"trigger_settings,omitempty"`
+}
+
+// ReplicationTriggerSettings represents trigger settings
+type ReplicationTriggerSettings struct {
+	Cron string `json:"cron,omitempty"`
+}
+
+// ReplicationFilter represents replication filter
+type ReplicationFilter struct {
+	Type       string      `json:"type"`
+	Value      interface{} `json:"value"`
+	Decoration string      `json:"decoration,omitempty"`
+}
+
+// ReplicationExecution represents a replication execution
+type ReplicationExecution struct {
+	ID         int64     `json:"id"`
+	PolicyID   int64     `json:"policy_id"`
+	Status     string    `json:"status"`
+	Trigger    string    `json:"trigger"`
+	StartTime  time.Time `json:"start_time"`
+	EndTime    time.Time `json:"end_time"`
+	StatusText string    `json:"status_text"`
+	Total      int       `json:"total"`
+	Failed     int       `json:"failed"`
+	Succeed    int       `json:"succeed"`
+	InProgress int       `json:"in_progress"`
+	Stopped    int       `json:"stopped"`
+}
+
+// StartReplicationExecution represents start execution request
+type StartReplicationExecution struct {
+	PolicyID int64 `json:"policy_id"`
+}
+
+// ReplicationTask represents a replication task
+type ReplicationTask struct {
+	ID           int64     `json:"id"`
+	ExecutionID  int64     `json:"execution_id"`
+	Status       string    `json:"status"`
+	JobID        string    `json:"job_id"`
+	Operation    string    `json:"operation"`
+	ResourceType string    `json:"resource_type"`
+	SrcResource  string    `json:"src_resource"`
+	DstResource  string    `json:"dst_resource"`
+	StartTime    time.Time `json:"start_time"`
+	EndTime      time.Time `json:"end_time"`
+}

--- a/pkg/harbor/replication.go
+++ b/pkg/harbor/replication.go
@@ -1,0 +1,194 @@
+package harbor
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/pascal71/hrbcli/pkg/api"
+)
+
+// ReplicationService handles replication operations
+type ReplicationService struct {
+	client *api.Client
+}
+
+// NewReplicationService creates a new ReplicationService
+func NewReplicationService(client *api.Client) *ReplicationService {
+	return &ReplicationService{client: client}
+}
+
+// ListPolicies lists replication policies
+func (s *ReplicationService) ListPolicies(opts *api.ListOptions) ([]*api.ReplicationPolicy, error) {
+	params := make(map[string]string)
+	if opts != nil {
+		if opts.Query != "" {
+			params["query"] = opts.Query
+		}
+		if opts.Sort != "" {
+			params["sort"] = opts.Sort
+		}
+		if opts.Page > 0 {
+			params["page"] = fmt.Sprintf("%d", opts.Page)
+		}
+		if opts.PageSize > 0 {
+			params["page_size"] = fmt.Sprintf("%d", opts.PageSize)
+		}
+	}
+
+	resp, err := s.client.Get("/replication/policies", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var policies []*api.ReplicationPolicy
+	if err := s.client.DecodeResponse(resp, &policies); err != nil {
+		return nil, fmt.Errorf("failed to decode policies: %w", err)
+	}
+
+	return policies, nil
+}
+
+// GetPolicy retrieves a policy by ID
+func (s *ReplicationService) GetPolicy(id int64) (*api.ReplicationPolicy, error) {
+	resp, err := s.client.Get(fmt.Sprintf("/replication/policies/%d", id), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var policy api.ReplicationPolicy
+	if err := s.client.DecodeResponse(resp, &policy); err != nil {
+		return nil, fmt.Errorf("failed to decode policy: %w", err)
+	}
+	return &policy, nil
+}
+
+// CreatePolicy creates a new replication policy
+func (s *ReplicationService) CreatePolicy(req *api.ReplicationPolicy) (*api.ReplicationPolicy, error) {
+	resp, err := s.client.Post("/replication/policies", req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	location := resp.Header.Get("Location")
+	if location == "" {
+		return nil, fmt.Errorf("no location header in response")
+	}
+
+	var id int64
+	if _, err := fmt.Sscanf(location, "/api/v2.0/replication/policies/%d", &id); err != nil {
+		return nil, fmt.Errorf("failed to parse policy ID from location: %s", location)
+	}
+
+	return s.GetPolicy(id)
+}
+
+// DeletePolicy deletes a replication policy
+func (s *ReplicationService) DeletePolicy(id int64) error {
+	resp, err := s.client.Delete(fmt.Sprintf("/replication/policies/%d", id))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// StartExecution manually triggers a replication execution
+func (s *ReplicationService) StartExecution(policyID int64) (*api.ReplicationExecution, error) {
+	req := &api.StartReplicationExecution{PolicyID: policyID}
+	resp, err := s.client.Post("/replication/executions", req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	location := resp.Header.Get("Location")
+	if location == "" {
+		return nil, fmt.Errorf("no location header in response")
+	}
+
+	var id int64
+	if _, err := fmt.Sscanf(location, "/api/v2.0/replication/executions/%d", &id); err != nil {
+		return nil, fmt.Errorf("failed to parse execution ID from location: %s", location)
+	}
+
+	return s.GetExecution(id)
+}
+
+// ListExecutions lists executions
+func (s *ReplicationService) ListExecutions(policyID int64) ([]*api.ReplicationExecution, error) {
+	params := make(map[string]string)
+	if policyID > 0 {
+		params["policy_id"] = fmt.Sprintf("%d", policyID)
+	}
+
+	resp, err := s.client.Get("/replication/executions", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var execs []*api.ReplicationExecution
+	if err := s.client.DecodeResponse(resp, &execs); err != nil {
+		return nil, fmt.Errorf("failed to decode executions: %w", err)
+	}
+	return execs, nil
+}
+
+// GetExecution retrieves a replication execution
+func (s *ReplicationService) GetExecution(id int64) (*api.ReplicationExecution, error) {
+	resp, err := s.client.Get(fmt.Sprintf("/replication/executions/%d", id), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var exec api.ReplicationExecution
+	if err := s.client.DecodeResponse(resp, &exec); err != nil {
+		return nil, fmt.Errorf("failed to decode execution: %w", err)
+	}
+	return &exec, nil
+}
+
+// ListTasks lists tasks for an execution
+func (s *ReplicationService) ListTasks(executionID int64) ([]*api.ReplicationTask, error) {
+	resp, err := s.client.Get(fmt.Sprintf("/replication/executions/%d/tasks", executionID), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var tasks []*api.ReplicationTask
+	if err := s.client.DecodeResponse(resp, &tasks); err != nil {
+		return nil, fmt.Errorf("failed to decode tasks: %w", err)
+	}
+	return tasks, nil
+}
+
+// GetTaskLog retrieves the log of a task
+func (s *ReplicationService) GetTaskLog(executionID, taskID int64) (string, error) {
+	resp, err := s.client.Get(fmt.Sprintf("/replication/executions/%d/tasks/%d/log", executionID, taskID), nil)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+	buf, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read log: %w", err)
+	}
+	return string(buf), nil
+}


### PR DESCRIPTION
## Summary
- implement replication data structures and service
- add cobra commands for replication management
- document replication CLI usage

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68476c774cb88325a342c06b6c5d645d