### PR TITLE
Add repository get command with detail option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ hrbcli project create myproject --public
 # List repositories in a project
 hrbcli repo list myproject
 
+# Get repository details
+hrbcli repo get myproject/myapp
+
 # List tags for a repository
 hrbcli repo tags myproject/myapp
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -96,6 +96,18 @@ hrbcli repo list myproject --detail
 hrbcli repo list myproject --filter "app*"
 ```
 
+#### `hrbcli repo get`
+
+Show details for a repository.
+
+```bash
+# Get repository information
+hrbcli repo get myproject/myapp
+
+# Include creation/update timestamps
+hrbcli repo get myproject/myapp --detail
+```
+
 #### `hrbcli repo delete`
 
 Delete a repository.

--- a/pkg/harbor/repository.go
+++ b/pkg/harbor/repository.go
@@ -2,6 +2,7 @@ package harbor
 
 import (
 	"fmt"
+	"net/url"
 	"strconv"
 
 	"github.com/pascal71/hrbcli/pkg/api"
@@ -47,4 +48,23 @@ func (s *RepositoryService) List(projectName string, opts *api.ListOptions) ([]*
 	}
 
 	return repos, nil
+}
+
+// Get retrieves a repository by name within a project
+func (s *RepositoryService) Get(projectName, repositoryName string) (*api.Repository, error) {
+	projectEsc := url.PathEscape(projectName)
+	repoEsc := url.PathEscape(repositoryName)
+	path := fmt.Sprintf("/projects/%s/repositories/%s", projectEsc, repoEsc)
+
+	resp, err := s.client.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var repo api.Repository
+	if err := s.client.DecodeResponse(resp, &repo); err != nil {
+		return nil, fmt.Errorf("failed to decode repository: %w", err)
+	}
+
+	return &repo, nil
 }


### PR DESCRIPTION
## Summary
- add `Get` method to `RepositoryService`
- implement `repo get` CLI command
- document repo get usage
- mention repo get in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68476e6401408325ae74075040352977