### PR TITLE
docs: clarify HARBOR_PASSWORD usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ export HARBOR_USERNAME=admin
 export HARBOR_PASSWORD=secretpassword
 ```
 
+`HARBOR_PASSWORD` can hold either your Harbor account password or a robot account token. Set it as an environment variable to avoid storing credentials in your configuration file.
+
 ## Documentation
 
 - [Command Reference](docs/COMMANDS.md) - Detailed documentation for all commands

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -35,6 +35,12 @@ We love your input! We want to make contributing to Harbor CLI as easy and trans
    make tools
    ```
 
+6. Set your Harbor credentials:
+   ```bash
+   export HARBOR_PASSWORD=yourpassword
+   ```
+   Storing the password in an environment variable keeps it out of your configuration file. See the README's Configuration section for more details.
+
 ## Development Workflow
 
 ### 1. Create a Branch


### PR DESCRIPTION
## Summary
- mention the `HARBOR_PASSWORD` environment variable in the README configuration section
- reference using `HARBOR_PASSWORD` in the contributing guide

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6847ca75299c8325b66036f2646e277a