### PR TITLE
Normalize spacing in version file

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,13 +7,10 @@ import (
 var (
 	// Version is the version of the CLI, set at build time
 	Version = "dev"
-	
 	// BuildTime is the time the CLI was built, set at build time
 	BuildTime = "unknown"
-	
 	// GoVersion is the version of Go used to build the CLI
 	GoVersion = runtime.Version()
-	
 	// Platform is the platform the CLI is running on
 	Platform = runtime.GOOS + "/" + runtime.GOARCH
 )


### PR DESCRIPTION
## Summary
- run gofmt and clean up blank lines in `internal/version/version.go`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6847ca6b2378832586e894c33c211a3a