### PR TITLE
Improve missing argument messages

### DIFF
--- a/cmd/args.go
+++ b/cmd/args.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// requireArgs returns a cobra.PositionalArgs validator that ensures the
+// command receives exactly n arguments. The msg parameter should describe
+// the expected argument(s) for a friendly error message.
+func requireArgs(n int, msg string) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) != n {
+			return fmt.Errorf("%s", msg)
+		}
+		return nil
+	}
+}

--- a/cmd/artifact.go
+++ b/cmd/artifact.go
@@ -35,7 +35,7 @@ func newArtifactScanCmd() *cobra.Command {
 		Use:   "scan <project>/<repository>[:tag|@digest]",
 		Short: "Scan an image",
 		Long:  `Trigger vulnerability scan for a specific image in Harbor.`,
-		Args:  cobra.ExactArgs(1),
+		Args:  requireArgs(1, "requires <project>/<repository>[:tag|@digest]"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			project, repo, ref, err := parseArtifactRef(args[0])
 			if err != nil {
@@ -116,7 +116,7 @@ func newArtifactListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list <project>[/<repository>]",
 		Short: "List artifacts",
-		Args:  cobra.ExactArgs(1),
+		Args:  requireArgs(1, "requires <project>[/<repository>]"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			project, repo, err := parseProjectRepo(args[0])
 			if err != nil {
@@ -234,7 +234,7 @@ func newArtifactVulnCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "vulnerabilities <project>/<repository>[:tag|@digest]",
 		Short: "Show vulnerability report",
-		Args:  cobra.ExactArgs(1),
+		Args:  requireArgs(1, "requires <project>/<repository>[:tag|@digest]"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			project, repo, ref, err := parseArtifactRef(args[0])
 			if err != nil {
@@ -303,7 +303,7 @@ func newArtifactSbomCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sbom <project>/<repository>[:tag|@digest]",
 		Short: "Show SBOM report",
-		Args:  cobra.ExactArgs(1),
+		Args:  requireArgs(1, "requires <project>/<repository>[:tag|@digest]"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			project, repo, ref, err := parseArtifactRef(args[0])
 			if err != nil {
@@ -343,7 +343,7 @@ func newArtifactGetCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get <project>/<repository>[:tag|@digest]",
 		Short: "Get artifact details",
-		Args:  cobra.ExactArgs(1),
+		Args:  requireArgs(1, "requires <project>/<repository>[:tag|@digest]"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			project, repo, ref, err := parseArtifactRef(args[0])
 			if err != nil {

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -14,7 +14,7 @@ func NewCompletionCmd() *cobra.Command {
 		Long:                  `Generate shell completion script for various shells.`,
 		DisableFlagsInUseLine: true,
 		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
-		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		Args:                  cobra.MatchAll(requireArgs(1, "requires one of: bash|zsh|fish|powershell"), cobra.OnlyValidArgs),
 		Run: func(cmd *cobra.Command, args []string) {
 			switch args[0] {
 			case "bash":

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -194,7 +194,7 @@ func newConfigSetCmd() *cobra.Command {
   - default_project: Default project name
   - no_color: Disable colored output (true, false)
   - debug: Enable debug output (true, false)`,
-		Args: cobra.ExactArgs(2),
+		Args: requireArgs(2, "requires <key> and <value>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			key := args[0]
 			value := args[1]

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -167,7 +167,7 @@ func newProjectCreateCmd() *cobra.Command {
 
   # Create with security settings
   hrbcli project create secure-proj --enable-content-trust --prevent-vulnerable --auto-scan`,
-		Args: cobra.ExactArgs(1),
+		Args: requireArgs(1, "requires <name>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			projectName := args[0]
 
@@ -315,7 +315,7 @@ func newProjectGetCmd() *cobra.Command {
 		Use:   "get <name>",
 		Short: "Get project details",
 		Long:  `Get detailed information about a specific project.`,
-		Args:  cobra.ExactArgs(1),
+		Args:  requireArgs(1, "requires <name>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			projectName := args[0]
 
@@ -439,7 +439,7 @@ func newProjectUpdateCmd() *cobra.Command {
 
   # Enable security features
   hrbcli project update myproject --enable-content-trust=true --auto-scan=true`,
-		Args: cobra.ExactArgs(1),
+		Args: requireArgs(1, "requires <name>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			projectName := args[0]
 
@@ -581,7 +581,7 @@ func newProjectDeleteCmd() *cobra.Command {
 		Use:   "delete <name>",
 		Short: "Delete a project",
 		Long:  `Delete a project. The project must be empty (no repositories).`,
-		Args:  cobra.ExactArgs(1),
+		Args:  requireArgs(1, "requires <name>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			projectName := args[0]
 
@@ -640,7 +640,7 @@ func newProjectExistsCmd() *cobra.Command {
 		Use:   "exists <name>",
 		Short: "Check if a project exists",
 		Long:  `Check if a project exists. Returns exit code 0 if exists, 1 if not.`,
-		Args:  cobra.ExactArgs(1),
+		Args:  requireArgs(1, "requires <name>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			projectName := args[0]
 

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -286,7 +286,7 @@ func newRegistryGetCmd() *cobra.Command {
 		Use:   "get <id>",
 		Short: "Get registry details",
 		Long:  `Get detailed information about a registry endpoint.`,
-		Args:  cobra.ExactArgs(1),
+		Args:  requireArgs(1, "requires <id>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id, err := strconv.ParseInt(args[0], 10, 64)
 			if err != nil {
@@ -351,7 +351,7 @@ func newRegistryUpdateCmd() *cobra.Command {
 		Use:   "update <id>",
 		Short: "Update registry endpoint",
 		Long:  `Update an existing registry endpoint configuration.`,
-		Args:  cobra.ExactArgs(1),
+		Args:  requireArgs(1, "requires <id>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id, err := strconv.ParseInt(args[0], 10, 64)
 			if err != nil {
@@ -429,7 +429,7 @@ func newRegistryDeleteCmd() *cobra.Command {
 		Use:   "delete <id>",
 		Short: "Delete registry endpoint",
 		Long:  `Delete a registry endpoint. The registry must not be used by any replication rules.`,
-		Args:  cobra.ExactArgs(1),
+		Args:  requireArgs(1, "requires <id>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id, err := strconv.ParseInt(args[0], 10, 64)
 			if err != nil {
@@ -651,7 +651,7 @@ func newRegistryAdapterInfoCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "adapter-info [TYPE]",
 		Short: "Show detailed information about a registry adapter",
-		Args:  cobra.ExactArgs(1),
+		Args:  requireArgs(1, "requires registry type"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			adapterType := args[0]
 

--- a/cmd/replication.go
+++ b/cmd/replication.go
@@ -73,7 +73,7 @@ func newReplicationGetCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get <id>",
 		Short: "Show replication policy",
-		Args:  cobra.ExactArgs(1),
+		Args:  requireArgs(1, "requires <id>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id, err := strconv.ParseInt(args[0], 10, 64)
 			if err != nil {
@@ -140,7 +140,7 @@ func newReplicationDeleteCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete <id>",
 		Short: "Delete replication policy",
-		Args:  cobra.ExactArgs(1),
+		Args:  requireArgs(1, "requires <id>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id, err := strconv.ParseInt(args[0], 10, 64)
 			if err != nil {
@@ -265,7 +265,7 @@ func newReplicationExecutionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "execution <id>",
 		Short: "Show execution details",
-		Args:  cobra.ExactArgs(1),
+		Args:  requireArgs(1, "requires <id>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id, err := strconv.ParseInt(args[0], 10, 64)
 			if err != nil {
@@ -305,7 +305,7 @@ func newReplicationLogsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logs <execution-id>",
 		Short: "Show execution logs",
-		Args:  cobra.ExactArgs(1),
+		Args:  requireArgs(1, "requires <execution-id>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id, err := strconv.ParseInt(args[0], 10, 64)
 			if err != nil {

--- a/cmd/repository.go
+++ b/cmd/repository.go
@@ -40,7 +40,7 @@ func newRepoListCmd() *cobra.Command {
 		Use:   "list <project>",
 		Short: "List repositories",
 		Long:  `List repositories in a project.`,
-		Args:  cobra.ExactArgs(1),
+		Args:  requireArgs(1, "requires <project>"),
 		Example: `  # List repositories
   hrbcli repo list myproject
 
@@ -140,7 +140,7 @@ func newRepoGetCmd() *cobra.Command {
 		Use:   "get <project>/<repository>",
 		Short: "Get repository details",
 		Long:  `Get detailed information about a repository.`,
-		Args:  cobra.ExactArgs(1),
+		Args:  requireArgs(1, "requires <project>/<repository>"),
 		Example: `  # Get repository details
   hrbcli repo get myproject/myrepo
 

--- a/cmd/scanner.go
+++ b/cmd/scanner.go
@@ -29,7 +29,7 @@ func newScannerRunningCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "running <project>[/<repository>]",
 		Short: "Show running scans",
-		Args:  cobra.ExactArgs(1),
+		Args:  requireArgs(1, "requires <project>[/<repository>]"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			project, repo, err := parseProjectRepo(args[0])
 			if err != nil {
@@ -116,14 +116,13 @@ func newScannerRunningCmd() *cobra.Command {
 	return cmd
 }
 
-
 func newScannerScanCmd() *cobra.Command {
 	var scanType string
 
 	cmd := &cobra.Command{
 		Use:   "scan <project>[/<repository>]",
 		Short: "Trigger scan for artifacts",
-		Args:  cobra.ExactArgs(1),
+		Args:  requireArgs(1, "requires <project>[/<repository>]"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			project, repo, err := parseProjectRepo(args[0])
 			if err != nil {
@@ -173,4 +172,3 @@ func newScannerScanCmd() *cobra.Command {
 
 	return cmd
 }
-

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -118,7 +118,7 @@ func newUserCreateCmd() *cobra.Command {
 		Use:   "create <username>",
 		Short: "Create a new user",
 		Long:  `Create a new Harbor user.`,
-		Args:  cobra.ExactArgs(1),
+		Args:  requireArgs(1, "requires <username>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			username := args[0]
 
@@ -184,7 +184,7 @@ func newUserDeleteCmd() *cobra.Command {
 		Use:   "delete <username>",
 		Short: "Delete a user",
 		Long:  `Delete a Harbor user by username.`,
-		Args:  cobra.ExactArgs(1),
+		Args:  requireArgs(1, "requires <username>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			username := args[0]
 


### PR DESCRIPTION
## Summary
- add helper for user-friendly argument validation
- use helper across commands

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684825f05f6c8325a9dd8ea410762ad3