### PR TITLE
Add report summary and listing commands

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -181,7 +181,7 @@ hrbcli artifact scan myproject/myapp --all
 
 #### `hrbcli artifact vulnerabilities`
 
-Show vulnerability report for an artifact. Use `--severity` to fail if vulnerabilities of that level or higher exist.
+Show vulnerability report for an artifact. Use `--summary` for an overview or `--severity` to fail if vulnerabilities of that level or higher exist.
 
 ```bash
 # Show vulnerabilities
@@ -232,6 +232,18 @@ hrbcli scanner scan myproject
 
 # Scan a single repository
 hrbcli scanner scan myproject/myrepo
+```
+
+#### `hrbcli scanner reports`
+
+Retrieve vulnerability or SBOM reports for artifacts in a project or repository.
+
+```bash
+# Vulnerability summary for a project
+hrbcli scanner reports myproject --summary
+
+# SBOM reports for a repository
+hrbcli scanner reports myproject/myrepo --type sbom
 ```
 
 ### User Management

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -213,3 +213,12 @@ type ArtifactListOptions struct {
 	WithSignature    bool `json:"-"`
 	WithScanOverview bool `json:"-"`
 }
+
+// ArtifactGetOptions represents options when retrieving a single artifact
+// to include additional details like scan overview.
+type ArtifactGetOptions struct {
+	WithTag          bool `json:"-"`
+	WithLabel        bool `json:"-"`
+	WithSignature    bool `json:"-"`
+	WithScanOverview bool `json:"-"`
+}

--- a/pkg/harbor/artifact.go
+++ b/pkg/harbor/artifact.go
@@ -62,15 +62,35 @@ func (s *ArtifactService) List(project, repository string, opts *api.ArtifactLis
 
 // Get retrieves details of a specific artifact
 func (s *ArtifactService) Get(project, repository, reference string) (*api.Artifact, error) {
+	opts := &api.ArtifactGetOptions{
+		WithTag:       true,
+		WithLabel:     true,
+		WithSignature: true,
+	}
+	return s.GetWithOptions(project, repository, reference, opts)
+}
+
+// GetWithOptions retrieves details of a specific artifact with optional parameters
+func (s *ArtifactService) GetWithOptions(project, repository, reference string, opts *api.ArtifactGetOptions) (*api.Artifact, error) {
 	projectEsc := url.PathEscape(project)
 	repoEsc := url.PathEscape(repository)
 	refEsc := url.PathEscape(reference)
 	path := fmt.Sprintf("/projects/%s/repositories/%s/artifacts/%s", projectEsc, repoEsc, refEsc)
 
-	params := map[string]string{
-		"with_tag":       "true",
-		"with_label":     "true",
-		"with_signature": "true",
+	params := make(map[string]string)
+	if opts != nil {
+		if opts.WithTag {
+			params["with_tag"] = "true"
+		}
+		if opts.WithLabel {
+			params["with_label"] = "true"
+		}
+		if opts.WithSignature {
+			params["with_signature"] = "true"
+		}
+		if opts.WithScanOverview {
+			params["with_scan_overview"] = "true"
+		}
 	}
 
 	resp, err := s.client.Get(path, params)


### PR DESCRIPTION
## Summary
- support retrieving scan overview when getting an artifact
- add `--summary` option to `artifact vulnerabilities`
- add `scanner reports` command to collect vulnerability or SBOM reports
- document new flags and command

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68482d3dee448325919a2458692cd4a1