### PR TITLE
Add report summary and listing commands

### DIFF
--- a/cmd/artifact.go
+++ b/cmd/artifact.go
@@ -229,7 +229,10 @@ func newArtifactListCmd() *cobra.Command {
 }
 
 func newArtifactVulnCmd() *cobra.Command {
-	var severity string
+	var (
+		severity string
+		summary  bool
+	)
 
 	cmd := &cobra.Command{
 		Use:   "vulnerabilities <project>/<repository>[:tag|@digest]",
@@ -247,13 +250,48 @@ func newArtifactVulnCmd() *cobra.Command {
 			}
 
 			artSvc := harbor.NewArtifactService(client)
+
+			if summary {
+				art, err := artSvc.GetWithOptions(project, repo, ref, &api.ArtifactGetOptions{WithScanOverview: true})
+				if err != nil {
+					return fmt.Errorf("failed to get summary: %w", err)
+				}
+				if len(art.ScanOverview) == 0 {
+					output.Info("No vulnerability summary available")
+					return nil
+				}
+				switch output.GetFormat() {
+				case "json":
+					return output.JSON(art.ScanOverview)
+				case "yaml":
+					return output.YAML(art.ScanOverview)
+				default:
+					table := output.Table()
+					table.Append([]string{"SCANNER", "STATUS", "SEVERITY", "COMPLETE"})
+					for name, ov := range art.ScanOverview {
+						table.Append([]string{name, ov.ScanStatus, ov.Severity, fmt.Sprintf("%d%%", ov.CompletePct)})
+					}
+					table.Render()
+					return nil
+				}
+			}
+
 			report, err := artSvc.Vulnerabilities(project, repo, ref)
 			if err != nil {
 				return fmt.Errorf("failed to get vulnerabilities: %w", err)
 			}
 
-			if report == nil || len(report.Vulnerabilities) == 0 {
+			if report == nil {
 				output.Info("No vulnerabilities found")
+				return nil
+			}
+
+			if len(report.Vulnerabilities) == 0 {
+				if report.Summary.Total == 0 {
+					output.Info("No vulnerabilities found")
+					return nil
+				}
+				output.Info("%d vulnerabilities found (summary only)", report.Summary.Total)
 				return nil
 			}
 
@@ -295,6 +333,7 @@ func newArtifactVulnCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&severity, "severity", "", "Fail if vulnerabilities of this severity or higher are found")
+	cmd.Flags().BoolVar(&summary, "summary", false, "Show vulnerability summary instead of detailed report")
 
 	return cmd
 }

--- a/cmd/scanner.go
+++ b/cmd/scanner.go
@@ -22,6 +22,8 @@ func NewScannerCmd() *cobra.Command {
 
 	cmd.AddCommand(newScannerScanCmd())
 
+	cmd.AddCommand(newScannerReportsCmd())
+
 	return cmd
 }
 
@@ -169,6 +171,137 @@ func newScannerScanCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&scanType, "scan-type", "", "Scan type (vulnerability|sbom)")
+
+	return cmd
+}
+
+func newScannerReportsCmd() *cobra.Command {
+	var reportType string
+	var summary bool
+
+	cmd := &cobra.Command{
+		Use:   "reports <project>[/<repository>]",
+		Short: "Get reports for artifacts",
+		Args:  requireArgs(1, "requires <project>[/<repository>]"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			project, repo, err := parseProjectRepo(args[0])
+			if err != nil {
+				return err
+			}
+
+			client, err := api.NewClient()
+			if err != nil {
+				return err
+			}
+
+			repoSvc := harbor.NewRepositoryService(client)
+			artSvc := harbor.NewArtifactService(client)
+
+			var repos []string
+			if repo != "" {
+				repos = []string{repo}
+			} else {
+				list, err := repoSvc.List(project, nil)
+				if err != nil {
+					return fmt.Errorf("failed to list repositories: %w", err)
+				}
+				for _, r := range list {
+					repos = append(repos, strings.TrimPrefix(r.Name, project+"/"))
+				}
+			}
+
+			type entry struct {
+				Repository string      `json:"repository"`
+				Reference  string      `json:"reference"`
+				Report     interface{} `json:"report"`
+			}
+			var reports []entry
+
+			for _, r := range repos {
+				arts, err := artSvc.List(project, r, &api.ArtifactListOptions{WithTag: true, WithScanOverview: summary})
+				if err != nil {
+					return fmt.Errorf("failed to list artifacts for %s: %w", r, err)
+				}
+				for _, a := range arts {
+					ref := a.Digest
+					if len(a.Tags) > 0 {
+						ref = a.Tags[0].Name
+					}
+
+					if summary {
+						reports = append(reports, entry{Repository: r, Reference: ref, Report: a.ScanOverview})
+						continue
+					}
+
+					if strings.ToLower(reportType) == "sbom" {
+						report, err := artSvc.SBOM(project, r, a.Digest)
+						if err != nil {
+							output.Warning("Failed to get SBOM for %s/%s@%s: %v", project, r, output.Truncate(a.Digest, 13), err)
+							continue
+						}
+						reports = append(reports, entry{Repository: r, Reference: ref, Report: report})
+					} else {
+						report, err := artSvc.Vulnerabilities(project, r, a.Digest)
+						if err != nil {
+							output.Warning("Failed to get vulnerabilities for %s/%s@%s: %v", project, r, output.Truncate(a.Digest, 13), err)
+							continue
+						}
+						reports = append(reports, entry{Repository: r, Reference: ref, Report: report})
+					}
+				}
+			}
+
+			if len(reports) == 0 {
+				output.Info("No reports found")
+				return nil
+			}
+
+			switch output.GetFormat() {
+			case "json":
+				return output.JSON(reports)
+			case "yaml":
+				return output.YAML(reports)
+			default:
+				table := output.Table()
+				if summary {
+					table.Append([]string{"REPOSITORY", "REFERENCE", "SCANNER", "STATUS", "SEVERITY"})
+					for _, e := range reports {
+						overview, ok := e.Report.(map[string]api.NativeReportSummary)
+						if !ok {
+							continue
+						}
+						for name, ov := range overview {
+							table.Append([]string{e.Repository, e.Reference, name, ov.ScanStatus, ov.Severity})
+						}
+					}
+				} else if strings.ToLower(reportType) == "sbom" {
+					table.Append([]string{"REPOSITORY", "REFERENCE", "SBOM"})
+					for _, e := range reports {
+						table.Append([]string{e.Repository, e.Reference, "available"})
+					}
+				} else {
+					table.Append([]string{"REPOSITORY", "REFERENCE", "VULNERABILITIES"})
+					for _, e := range reports {
+						rep, ok := e.Report.(*api.VulnerabilityReport)
+						if !ok || rep == nil {
+							table.Append([]string{e.Repository, e.Reference, ""})
+							continue
+						}
+						count := len(rep.Vulnerabilities)
+						if count == 0 && rep.Summary.Total > 0 {
+							count = rep.Summary.Total
+						}
+						table.Append([]string{e.Repository, e.Reference, fmt.Sprintf("%d", count)})
+					}
+				}
+				table.Render()
+				return nil
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&reportType, "type", "vulnerability", "Report type (vulnerability|sbom)")
+	cmd.Flags().BoolVar(&summary, "summary", false, "Show summary instead of full report")
 
 	return cmd
 }

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -181,7 +181,7 @@ hrbcli artifact scan myproject/myapp --all
 
 #### `hrbcli artifact vulnerabilities`
 
-Show vulnerability report for an artifact. Use `--severity` to fail if vulnerabilities of that level or higher exist.
+Show vulnerability report for an artifact. Use `--summary` for an overview or `--severity` to fail if vulnerabilities of that level or higher exist.
 
 ```bash
 # Show vulnerabilities
@@ -232,6 +232,18 @@ hrbcli scanner scan myproject
 
 # Scan a single repository
 hrbcli scanner scan myproject/myrepo
+```
+
+#### `hrbcli scanner reports`
+
+Retrieve vulnerability or SBOM reports for artifacts in a project or repository.
+
+```bash
+# Vulnerability summary for a project
+hrbcli scanner reports myproject --summary
+
+# SBOM reports for a repository
+hrbcli scanner reports myproject/myrepo --type sbom
 ```
 
 ### User Management

--- a/pkg/api/scanner_types.go
+++ b/pkg/api/scanner_types.go
@@ -3,7 +3,16 @@ package api
 // VulnerabilityReport represents a vulnerability scanning report
 // Only fields needed by the CLI are included.
 type VulnerabilityReport struct {
-	Vulnerabilities []VulnerabilityItem `json:"vulnerabilities"`
+	Severity        string               `json:"severity"`
+	Summary         VulnerabilitySummary `json:"summary"`
+	Vulnerabilities []VulnerabilityItem  `json:"vulnerabilities"`
+}
+
+// VulnerabilitySummary contains summary information about the
+// vulnerabilities found in a scan.
+type VulnerabilitySummary struct {
+	Total   int `json:"total"`
+	Fixable int `json:"fixable"`
 }
 
 // VulnerabilityItem represents a single vulnerability entry

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -213,3 +213,12 @@ type ArtifactListOptions struct {
 	WithSignature    bool `json:"-"`
 	WithScanOverview bool `json:"-"`
 }
+
+// ArtifactGetOptions represents options when retrieving a single artifact
+// to include additional details like scan overview.
+type ArtifactGetOptions struct {
+	WithTag          bool `json:"-"`
+	WithLabel        bool `json:"-"`
+	WithSignature    bool `json:"-"`
+	WithScanOverview bool `json:"-"`
+}

--- a/pkg/harbor/artifact.go
+++ b/pkg/harbor/artifact.go
@@ -62,15 +62,35 @@ func (s *ArtifactService) List(project, repository string, opts *api.ArtifactLis
 
 // Get retrieves details of a specific artifact
 func (s *ArtifactService) Get(project, repository, reference string) (*api.Artifact, error) {
+	opts := &api.ArtifactGetOptions{
+		WithTag:       true,
+		WithLabel:     true,
+		WithSignature: true,
+	}
+	return s.GetWithOptions(project, repository, reference, opts)
+}
+
+// GetWithOptions retrieves details of a specific artifact with optional parameters
+func (s *ArtifactService) GetWithOptions(project, repository, reference string, opts *api.ArtifactGetOptions) (*api.Artifact, error) {
 	projectEsc := url.PathEscape(project)
 	repoEsc := url.PathEscape(repository)
 	refEsc := url.PathEscape(reference)
 	path := fmt.Sprintf("/projects/%s/repositories/%s/artifacts/%s", projectEsc, repoEsc, refEsc)
 
-	params := map[string]string{
-		"with_tag":       "true",
-		"with_label":     "true",
-		"with_signature": "true",
+	params := make(map[string]string)
+	if opts != nil {
+		if opts.WithTag {
+			params["with_tag"] = "true"
+		}
+		if opts.WithLabel {
+			params["with_label"] = "true"
+		}
+		if opts.WithSignature {
+			params["with_signature"] = "true"
+		}
+		if opts.WithScanOverview {
+			params["with_scan_overview"] = "true"
+		}
 	}
 
 	resp, err := s.client.Get(path, params)


### PR DESCRIPTION
## Summary
- support retrieving scan overview when getting an artifact
- add `--summary` option to `artifact vulnerabilities`
- add `scanner reports` command to collect vulnerability or SBOM reports
- document new flags and command
- fix vulnerability count handling in reports

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68482d3dee448325919a2458692cd4a1