### PR TITLE
Add Harbor configuration commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A powerful command-line interface for [Harbor](https://goharbor.io/) container r
 - 📚 **Comprehensive Documentation** - Built-in help for all commands
 - 🔄 **Shell Completions** - Bash, Zsh, and Fish shell completions
 - 🚚 **Distribution Management** - Manage preheat providers and policies
+- 🛠 **System Configuration** - View and update Harbor system settings
 
 ## Installation
 
@@ -82,6 +83,9 @@ hrbcli system info
 
 # Show Harbor statistics
 hrbcli system statistics
+
+# View Harbor configuration
+hrbcli system config get
 
 ```
 

--- a/cmd/system.go
+++ b/cmd/system.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -20,6 +21,7 @@ func NewSystemCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(newSystemStatisticsCmd())
+	cmd.AddCommand(newSystemConfigCmd())
 
 	return cmd
 }
@@ -75,4 +77,107 @@ func newSystemStatisticsCmd() *cobra.Command {
 	}
 
 	return cmd
+}
+
+func newSystemConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Manage Harbor configuration",
+	}
+
+	cmd.AddCommand(newSystemConfigGetCmd())
+	cmd.AddCommand(newSystemConfigSetCmd())
+
+	return cmd
+}
+
+func newSystemConfigGetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get [key]",
+		Short: "Get Harbor configuration",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := api.NewClient()
+			if err != nil {
+				return err
+			}
+
+			sysSvc := harbor.NewSystemService(client)
+
+			cfg, err := sysSvc.GetConfig()
+			if err != nil {
+				return fmt.Errorf("failed to get configuration: %w", err)
+			}
+
+			if len(args) == 1 {
+				key := args[0]
+				val, ok := cfg[key]
+				if !ok {
+					return fmt.Errorf("configuration key '%s' not found", key)
+				}
+				switch output.GetFormat() {
+				case "json":
+					return output.JSON(val)
+				case "yaml":
+					return output.YAML(val)
+				default:
+					fmt.Printf("%s: %v\n", key, val)
+					return nil
+				}
+			}
+
+			switch output.GetFormat() {
+			case "json":
+				return output.JSON(cfg)
+			case "yaml":
+				return output.YAML(cfg)
+			default:
+				table := output.Table()
+				table.Append([]string{"KEY", "VALUE"})
+				keys := make([]string, 0, len(cfg))
+				for k := range cfg {
+					keys = append(keys, k)
+				}
+				sort.Strings(keys)
+				for _, k := range keys {
+					table.Append([]string{k, fmt.Sprintf("%v", cfg[k])})
+				}
+				table.Render()
+				return nil
+			}
+		},
+	}
+}
+
+func newSystemConfigSetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set <key> <value>",
+		Short: "Set Harbor configuration value",
+		Args:  requireArgs(2, "requires <key> <value>"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key := args[0]
+			value := args[1]
+
+			var typed interface{} = value
+			if value == "true" {
+				typed = true
+			} else if value == "false" {
+				typed = false
+			}
+
+			client, err := api.NewClient()
+			if err != nil {
+				return err
+			}
+
+			sysSvc := harbor.NewSystemService(client)
+			update := map[string]interface{}{key: typed}
+			if err := sysSvc.UpdateConfig(update); err != nil {
+				return fmt.Errorf("failed to update configuration: %w", err)
+			}
+
+			output.Success("Updated %s", key)
+			return nil
+		},
+	}
 }

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -339,6 +339,27 @@ hrbcli system health --component core
 hrbcli system health --component jobservice
 ```
 
+#### `hrbcli system config get`
+
+Retrieve Harbor configuration values.
+
+```bash
+# Get all configuration
+hrbcli system config get
+
+# Get specific key
+hrbcli system config get auth_mode
+```
+
+#### `hrbcli system config set`
+
+Update Harbor configuration values.
+
+```bash
+# Enable self-registration
+hrbcli system config set self_registration true
+```
+
 #### `hrbcli system gc`
 
 Manage garbage collection.


### PR DESCRIPTION
## Summary
- add system configuration support in CLI
- update documentation for new commands
- update README with system configuration bullet and example

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68486e583c0083259666a0ed53767804