### PR TITLE
Add garbage collection support

### DIFF
--- a/cmd/system.go
+++ b/cmd/system.go
@@ -20,6 +20,7 @@ func NewSystemCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(newSystemStatisticsCmd())
+	cmd.AddCommand(newSystemGCCmd())
 
 	return cmd
 }
@@ -74,5 +75,127 @@ func newSystemStatisticsCmd() *cobra.Command {
 		},
 	}
 
+	return cmd
+}
+
+func newSystemGCCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "gc",
+		Short: "Manage garbage collection",
+	}
+
+	cmd.AddCommand(newSystemGCScheduleCmd())
+	cmd.AddCommand(newSystemGCHistoryCmd())
+	cmd.AddCommand(newSystemGCStatusCmd())
+
+	return cmd
+}
+
+func newSystemGCScheduleCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "schedule",
+		Short: "Schedule garbage collection",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := api.NewClient()
+			if err != nil {
+				return err
+			}
+			sysSvc := harbor.NewSystemService(client)
+			id, err := sysSvc.StartGC()
+			if err != nil {
+				return fmt.Errorf("failed to schedule GC: %w", err)
+			}
+			if id > 0 {
+				output.Success("GC job %d scheduled", id)
+			} else {
+				output.Success("GC scheduled")
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newSystemGCHistoryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "history",
+		Short: "Show garbage collection history",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := api.NewClient()
+			if err != nil {
+				return err
+			}
+			sysSvc := harbor.NewSystemService(client)
+			history, err := sysSvc.GCHistory(nil)
+			if err != nil {
+				return fmt.Errorf("failed to get GC history: %w", err)
+			}
+
+			if len(history) == 0 {
+				output.Info("No GC history found")
+				return nil
+			}
+
+			switch output.GetFormat() {
+			case "json":
+				return output.JSON(history)
+			case "yaml":
+				return output.YAML(history)
+			default:
+				table := output.Table()
+				table.Append([]string{"ID", "STATUS", "JOB", "CREATED"})
+				for _, h := range history {
+					table.Append([]string{
+						strconv.FormatInt(h.ID, 10),
+						h.JobStatus,
+						h.JobName,
+						h.CreationTime.Format("2006-01-02 15:04:05"),
+					})
+				}
+				table.Render()
+				return nil
+			}
+		},
+	}
+	return cmd
+}
+
+func newSystemGCStatusCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "status <id>",
+		Short: "Show garbage collection job status",
+		Args:  requireArgs(1, "requires <id>"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid id: %w", err)
+			}
+			client, err := api.NewClient()
+			if err != nil {
+				return err
+			}
+			sysSvc := harbor.NewSystemService(client)
+			gc, err := sysSvc.GCStatus(id)
+			if err != nil {
+				return fmt.Errorf("failed to get GC status: %w", err)
+			}
+
+			switch output.GetFormat() {
+			case "json":
+				return output.JSON(gc)
+			case "yaml":
+				return output.YAML(gc)
+			default:
+				table := output.Table()
+				table.Append([]string{"FIELD", "VALUE"})
+				table.Append([]string{"ID", strconv.FormatInt(gc.ID, 10)})
+				table.Append([]string{"STATUS", gc.JobStatus})
+				table.Append([]string{"JOB", gc.JobName})
+				table.Append([]string{"CREATED", gc.CreationTime.Format("2006-01-02 15:04:05")})
+				table.Render()
+				return nil
+			}
+		},
+	}
 	return cmd
 }

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -222,3 +222,29 @@ type ArtifactGetOptions struct {
 	WithSignature    bool `json:"-"`
 	WithScanOverview bool `json:"-"`
 }
+
+// Schedule represents a job schedule
+type Schedule struct {
+	Type string `json:"type"`
+	Cron string `json:"cron,omitempty"`
+}
+
+// ScheduleObj represents schedule information returned by Harbor
+type ScheduleObj struct {
+	Type              string    `json:"type"`
+	Cron              string    `json:"cron,omitempty"`
+	NextScheduledTime time.Time `json:"next_scheduled_time,omitempty"`
+}
+
+// GCHistory represents a garbage collection execution
+type GCHistory struct {
+	ID            int64        `json:"id"`
+	JobName       string       `json:"job_name"`
+	JobKind       string       `json:"job_kind"`
+	JobParameters string       `json:"job_parameters"`
+	Schedule      *ScheduleObj `json:"schedule,omitempty"`
+	JobStatus     string       `json:"job_status"`
+	Deleted       bool         `json:"deleted"`
+	CreationTime  time.Time    `json:"creation_time"`
+	UpdateTime    time.Time    `json:"update_time"`
+}

--- a/pkg/harbor/system.go
+++ b/pkg/harbor/system.go
@@ -2,6 +2,7 @@ package harbor
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/pascal71/hrbcli/pkg/api"
 )
@@ -29,4 +30,68 @@ func (s *SystemService) GetStatistics() (*api.Statistic, error) {
 	}
 
 	return &stats, nil
+}
+
+// StartGC triggers a manual garbage collection job.
+// It returns the ID of the GC job if available.
+func (s *SystemService) StartGC() (int64, error) {
+	body := map[string]interface{}{
+		"schedule": api.Schedule{Type: "Manual"},
+	}
+	resp, err := s.client.Post("/system/gc/schedule", body)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return 0, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	location := resp.Header.Get("Location")
+	if location == "" {
+		return 0, nil
+	}
+	var id int64
+	fmt.Sscanf(location, "/api/%*s/system/gc/%d", &id)
+	return id, nil
+}
+
+// GCHistory retrieves past garbage collection executions
+func (s *SystemService) GCHistory(opts *api.ListOptions) ([]*api.GCHistory, error) {
+	params := make(map[string]string)
+	if opts != nil {
+		if opts.Page > 0 {
+			params["page"] = fmt.Sprintf("%d", opts.Page)
+		}
+		if opts.PageSize > 0 {
+			params["page_size"] = fmt.Sprintf("%d", opts.PageSize)
+		}
+	}
+	resp, err := s.client.Get("/system/gc", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var history []*api.GCHistory
+	if err := s.client.DecodeResponse(resp, &history); err != nil {
+		return nil, fmt.Errorf("failed to decode gc history: %w", err)
+	}
+
+	return history, nil
+}
+
+// GCStatus retrieves a garbage collection job by ID
+func (s *SystemService) GCStatus(id int64) (*api.GCHistory, error) {
+	resp, err := s.client.Get(fmt.Sprintf("/system/gc/%d", id), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var gc api.GCHistory
+	if err := s.client.DecodeResponse(resp, &gc); err != nil {
+		return nil, fmt.Errorf("failed to decode gc status: %w", err)
+	}
+
+	return &gc, nil
 }


### PR DESCRIPTION
## Summary
- add GC types for schedule and history
- implement GC operations in SystemService
- add `system gc` commands to schedule GC, view history and status

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68486d894588832594bcb7305523e365