### PR TITLE
Add job service dashboard command

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ hrbcli system info
 # Show Harbor statistics
 hrbcli system statistics
 
+# Show job service dashboard
+hrbcli jobservice dashboard
+
 ```
 
 ### Scanner Commands

--- a/cmd/jobservice.go
+++ b/cmd/jobservice.go
@@ -1,0 +1,116 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"strconv"
+
+	"github.com/pascal71/hrbcli/pkg/api"
+	"github.com/pascal71/hrbcli/pkg/harbor"
+	"github.com/pascal71/hrbcli/pkg/output"
+)
+
+// NewJobServiceCmd creates the jobservice command
+func NewJobServiceCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "jobservice",
+		Short: "Manage Harbor job service",
+	}
+
+	cmd.AddCommand(newJobServiceDashboardCmd())
+
+	return cmd
+}
+
+func newJobServiceDashboardCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "dashboard",
+		Short: "Show job service dashboard",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := api.NewClient()
+			if err != nil {
+				return err
+			}
+			svc := harbor.NewJobService(client)
+
+			pools, err := svc.GetWorkerPools()
+			if err != nil {
+				return err
+			}
+			workers, err := svc.GetWorkers("all")
+			if err != nil {
+				return err
+			}
+			queues, err := svc.ListJobQueues()
+			if err != nil {
+				return err
+			}
+
+			switch output.GetFormat() {
+			case "json":
+				data := struct {
+					Pools   []*api.WorkerPool `json:"pools"`
+					Workers []*api.Worker     `json:"workers"`
+					Queues  []*api.JobQueue   `json:"queues"`
+				}{pools, workers, queues}
+				return output.JSON(data)
+			case "yaml":
+				data := struct {
+					Pools   []*api.WorkerPool `yaml:"pools"`
+					Workers []*api.Worker     `yaml:"workers"`
+					Queues  []*api.JobQueue   `yaml:"queues"`
+				}{pools, workers, queues}
+				return output.YAML(data)
+			default:
+				table := output.Table()
+				table.Append([]string{"POOL ID", "PID", "HOST", "CONC", "START", "HEARTBEAT"})
+				for _, p := range pools {
+					table.Append([]string{
+						p.WorkerPoolID,
+						strconv.FormatInt(p.PID, 10),
+						p.Host,
+						strconv.Itoa(p.Concurrency),
+						p.StartAt.Format("2006-01-02 15:04:05"),
+						p.HeartbeatAt.Format("2006-01-02 15:04:05"),
+					})
+				}
+				table.Render()
+
+				table = output.Table()
+				table.Append([]string{"WORKER ID", "POOL", "JOB", "JOB ID", "START", "CHECKIN"})
+				for _, w := range workers {
+					start := ""
+					if !w.StartAt.IsZero() {
+						start = w.StartAt.Format("2006-01-02 15:04:05")
+					}
+					check := w.CheckIn
+					if w.CheckInAt.After(w.StartAt) {
+						check = w.CheckIn + " @ " + w.CheckInAt.Format("2006-01-02 15:04:05")
+					}
+					table.Append([]string{
+						w.ID,
+						w.PoolID,
+						w.JobName,
+						w.JobID,
+						start,
+						check,
+					})
+				}
+				table.Render()
+
+				table = output.Table()
+				table.Append([]string{"JOB TYPE", "COUNT", "LATENCY", "PAUSED"})
+				for _, q := range queues {
+					table.Append([]string{
+						q.JobType,
+						strconv.Itoa(q.Count),
+						strconv.Itoa(q.Latency),
+						strconv.FormatBool(q.Paused),
+					})
+				}
+				table.Render()
+				return nil
+			}
+		},
+	}
+	return cmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -97,6 +97,7 @@ func init() {
 	rootCmd.AddCommand(NewReplicationCmd())
 	rootCmd.AddCommand(NewDistributionCmd())
 	rootCmd.AddCommand(NewScannerCmd())
+	rootCmd.AddCommand(NewJobServiceCmd())
 	// rootCmd.AddCommand(NewUserCmd())
 	rootCmd.AddCommand(NewSystemCmd())
 	rootCmd.AddCommand(NewConfigCmd())

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -474,6 +474,16 @@ Show details of a distribution policy.
 hrbcli distribution policy myproject mypolicy
 ```
 
+### Job Service
+
+#### `hrbcli jobservice dashboard`
+
+Display job service worker pools, workers and job queues.
+
+```bash
+hrbcli jobservice dashboard
+```
+
 ### Configuration
 
 #### `hrbcli config init`

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -222,3 +222,32 @@ type ArtifactGetOptions struct {
 	WithSignature    bool `json:"-"`
 	WithScanOverview bool `json:"-"`
 }
+
+// WorkerPool represents a job service worker pool
+type WorkerPool struct {
+	PID          int64     `json:"pid"`
+	WorkerPoolID string    `json:"worker_pool_id"`
+	StartAt      time.Time `json:"start_at"`
+	HeartbeatAt  time.Time `json:"heartbeat_at"`
+	Concurrency  int       `json:"concurrency"`
+	Host         string    `json:"host"`
+}
+
+// Worker represents a worker in a pool
+type Worker struct {
+	ID        string    `json:"id"`
+	PoolID    string    `json:"pool_id"`
+	JobName   string    `json:"job_name"`
+	JobID     string    `json:"job_id"`
+	StartAt   time.Time `json:"start_at"`
+	CheckIn   string    `json:"check_in"`
+	CheckInAt time.Time `json:"checkin_at"`
+}
+
+// JobQueue represents a job queue summary
+type JobQueue struct {
+	JobType string `json:"job_type"`
+	Count   int    `json:"count"`
+	Latency int    `json:"latency"`
+	Paused  bool   `json:"paused"`
+}

--- a/pkg/harbor/jobservice.go
+++ b/pkg/harbor/jobservice.go
@@ -1,0 +1,57 @@
+package harbor
+
+import (
+	"fmt"
+
+	"github.com/pascal71/hrbcli/pkg/api"
+)
+
+// JobService handles job service operations
+// such as retrieving worker pools and job queues.
+type JobService struct {
+	client *api.Client
+}
+
+// NewJobService creates a new JobService
+func NewJobService(client *api.Client) *JobService {
+	return &JobService{client: client}
+}
+
+// GetWorkerPools retrieves worker pools
+func (s *JobService) GetWorkerPools() ([]*api.WorkerPool, error) {
+	resp, err := s.client.Get("/jobservice/pools", nil)
+	if err != nil {
+		return nil, err
+	}
+	var pools []*api.WorkerPool
+	if err := s.client.DecodeResponse(resp, &pools); err != nil {
+		return nil, fmt.Errorf("failed to decode worker pools: %w", err)
+	}
+	return pools, nil
+}
+
+// GetWorkers retrieves workers in a pool. Use poolID="all" to get all workers.
+func (s *JobService) GetWorkers(poolID string) ([]*api.Worker, error) {
+	resp, err := s.client.Get(fmt.Sprintf("/jobservice/pools/%s/workers", poolID), nil)
+	if err != nil {
+		return nil, err
+	}
+	var workers []*api.Worker
+	if err := s.client.DecodeResponse(resp, &workers); err != nil {
+		return nil, fmt.Errorf("failed to decode workers: %w", err)
+	}
+	return workers, nil
+}
+
+// ListJobQueues lists job queues
+func (s *JobService) ListJobQueues() ([]*api.JobQueue, error) {
+	resp, err := s.client.Get("/jobservice/queues", nil)
+	if err != nil {
+		return nil, err
+	}
+	var queues []*api.JobQueue
+	if err := s.client.DecodeResponse(resp, &queues); err != nil {
+		return nil, fmt.Errorf("failed to decode job queues: %w", err)
+	}
+	return queues, nil
+}


### PR DESCRIPTION
## Summary
- implement job service client and CLI command
- wire jobservice command into root
- document new command in README and COMMANDS docs

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68486dbb277c8325a8219df5737a197f