### PR TITLE
Improve user creation conflict error message

### DIFF
--- a/cmd/system.go
+++ b/cmd/system.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"sort"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -81,7 +80,7 @@ func newSystemStatisticsCmd() *cobra.Command {
 
 func newSystemConfigCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "config",
+		Use: "config",
 
 		Short: "Manage Harbor system configuration",
 	}
@@ -93,11 +92,11 @@ func newSystemConfigCmd() *cobra.Command {
 
 func newSystemConfigGetCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "get [key]",
+		Use: "get [key]",
 
 		Short: "Get Harbor system configuration",
 
-		Args:  cobra.MaximumNArgs(1),
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := api.NewClient()
 			if err != nil {

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -147,6 +148,13 @@ func newUserCreateCmd() *cobra.Command {
 
 			user, err := userSvc.Create(req)
 			if err != nil {
+				if apiErr, ok := err.(*api.APIError); ok && apiErr.IsConflict() {
+					msg := apiErr.FriendlyMessage()
+					if msg == "" {
+						msg = "user or email already exists"
+					}
+					return errors.New(msg)
+				}
 				return fmt.Errorf("failed to create user: %w", err)
 			}
 

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -12,6 +12,21 @@ type APIError struct {
 	Details map[string]interface{} `json:"details,omitempty"`
 }
 
+// FriendlyMessage attempts to extract a human-friendly message from the
+// underlying Harbor API error response. If the message contains a JSON
+// structure like {"errors":[{"message":"..."}]}, the first message is returned.
+func (e *APIError) FriendlyMessage() string {
+	var wrapper struct {
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal([]byte(e.Message), &wrapper); err == nil && len(wrapper.Errors) > 0 {
+		return wrapper.Errors[0].Message
+	}
+	return e.Message
+}
+
 // Error implements the error interface
 func (e *APIError) Error() string {
 	if e.Details != nil {


### PR DESCRIPTION
## Summary
- add `FriendlyMessage` helper on `api.APIError`
- show a clearer error when `hrbcli user create` hits a 409 conflict
- remove unused `sort` import in `cmd/system.go`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68487340d1a88325906470bc77bfde6d