### PR TITLE
Add repo deletion, tag listing, and system info/health

### DIFF
--- a/pkg/harbor/artifact.go
+++ b/pkg/harbor/artifact.go
@@ -170,3 +170,22 @@ func (s *ArtifactService) SBOM(project, repository, reference string) (map[strin
 
 	return report, nil
 }
+
+// Delete removes the specified artifact identified by tag or digest.
+func (s *ArtifactService) Delete(project, repository, reference string) error {
+	projectEsc := url.PathEscape(project)
+	repoEsc := url.PathEscape(repository)
+	refEsc := url.PathEscape(reference)
+	path := fmt.Sprintf("/projects/%s/repositories/%s/artifacts/%s", projectEsc, repoEsc, refEsc)
+
+	resp, err := s.client.Delete(path)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/pkg/harbor/repository.go
+++ b/pkg/harbor/repository.go
@@ -2,6 +2,7 @@ package harbor
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 
@@ -68,4 +69,64 @@ func (s *RepositoryService) Get(projectName, repositoryName string) (*api.Reposi
 	}
 
 	return &repo, nil
+}
+
+// Delete removes a repository from a project
+func (s *RepositoryService) Delete(projectName, repositoryName string) error {
+	projectEsc := url.PathEscape(projectName)
+	repoEsc := url.PathEscape(repositoryName)
+	path := fmt.Sprintf("/projects/%s/repositories/%s", projectEsc, repoEsc)
+
+	resp, err := s.client.Delete(path)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// ListTags lists all tags for a repository
+func (s *RepositoryService) ListTags(projectName, repositoryName string, opts *api.ListOptions) ([]*api.ArtifactTag, error) {
+	projectEsc := url.PathEscape(projectName)
+	repoEsc := url.PathEscape(repositoryName)
+	path := fmt.Sprintf("/projects/%s/repositories/%s/artifacts", projectEsc, repoEsc)
+
+	params := map[string]string{"with_tag": "true"}
+	if opts != nil {
+		if opts.Query != "" {
+			params["q"] = opts.Query
+		}
+		if opts.Sort != "" {
+			params["sort"] = opts.Sort
+		}
+		if opts.Page > 0 {
+			params["page"] = strconv.Itoa(opts.Page)
+		}
+		if opts.PageSize > 0 {
+			params["page_size"] = strconv.Itoa(opts.PageSize)
+		}
+	}
+
+	resp, err := s.client.Get(path, params)
+	if err != nil {
+		return nil, err
+	}
+
+	var artifacts []*api.Artifact
+	if err := s.client.DecodeResponse(resp, &artifacts); err != nil {
+		return nil, fmt.Errorf("failed to decode artifacts: %w", err)
+	}
+
+	var tags []*api.ArtifactTag
+	for _, a := range artifacts {
+		for _, t := range a.Tags {
+			tag := t
+			tags = append(tags, &api.ArtifactTag{Name: tag.Name, Immutable: tag.Immutable})
+		}
+	}
+	return tags, nil
 }


### PR DESCRIPTION
## Summary
- support deleting repositories or specific artifact references
- add repo tags listing
- show system info and health via new commands
- expose API methods for artifact delete and repo operations

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684876323f088325ac022bb5eeee7875