### PR TITLE
Add garbage collection commands

### DIFF
--- a/pkg/api/system_types.go
+++ b/pkg/api/system_types.go
@@ -1,0 +1,22 @@
+package api
+
+import "time"
+
+// Schedule represents a job schedule configuration.
+type Schedule struct {
+	Type string `json:"type"`
+	Cron string `json:"cron,omitempty"`
+}
+
+// GCHistory represents a garbage collection execution record.
+type GCHistory struct {
+	ID            int64     `json:"id"`
+	JobName       string    `json:"job_name"`
+	JobKind       string    `json:"job_kind"`
+	JobParameters string    `json:"job_parameters"`
+	Schedule      *Schedule `json:"schedule,omitempty"`
+	JobStatus     string    `json:"job_status"`
+	Deleted       bool      `json:"deleted"`
+	CreationTime  time.Time `json:"creation_time"`
+	UpdateTime    time.Time `json:"update_time"`
+}


### PR DESCRIPTION
## Summary
- add GC schedule/history/status commands
- implement GC API client functions
- define types for GC in `pkg/api`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68487945f2ac83259e0cf7ccfc4ee190