### PR TITLE
Add sort options to scanner reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ hrbcli jobservice dashboard
 hrbcli scanner scan <project>
 hrbcli scanner running <project>
 hrbcli scanner reports <project> --summary
+hrbcli scanner reports <project> --sort repo
 ```
 
 ### Distribution Commands

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -248,7 +248,7 @@ hrbcli scanner scan myproject/myrepo
 
 #### `hrbcli scanner reports`
 
-Retrieve vulnerability or SBOM reports for artifacts in a project or repository. When used with `--summary`, displays counts of vulnerabilities by severity for each artifact. Use `--output-dir` to download the reports for all artifacts to a directory.
+Retrieve vulnerability or SBOM reports for artifacts in a project or repository. When used with `--summary`, displays counts of vulnerabilities by severity for each artifact. Use `--output-dir` to download the reports for all artifacts to a directory. Results are sorted by vulnerability count by default; use `--sort` and `--reverse` to change ordering.
 
 
 ```bash


### PR DESCRIPTION
## Summary
- add table sorting for `scanner reports`
- document default sorting and new options

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68487caeeed083259cf549e57b3e1096