### PR TITLE
Add severity sort option for scanner reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ hrbcli scanner scan <project>
 hrbcli scanner running <project>
 hrbcli scanner reports <project> --summary
 hrbcli scanner reports <project> --sort repo
+hrbcli scanner reports <project> --sort crit
 ```
 
 ### Distribution Commands

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -322,7 +322,7 @@ hrbcli scanner scan myproject/myrepo
 
 #### `hrbcli scanner reports`
 
-Retrieve vulnerability or SBOM reports for artifacts in a project or repository. When used with `--summary`, displays counts of vulnerabilities by severity for each artifact. Use `--output-dir` to download the reports for all artifacts to a directory. Results are sorted by vulnerability count by default; use `--sort` and `--reverse` to change ordering.
+Retrieve vulnerability or SBOM reports for artifacts in a project or repository. When used with `--summary`, displays counts of vulnerabilities by severity for each artifact. Use `--output-dir` to download the reports for all artifacts to a directory. Results are sorted by severity (critical, high, medium, low, total, repository) by default; use `--sort` and `--reverse` to change ordering.
 
 
 ```bash


### PR DESCRIPTION
## Summary
- support sorting scanner summary by severity counts
- default sort order: critical, high, medium, low, total, repository
- document new sorting options and example usage

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68487f6f70d48325856984c890f3d487