### PR TITLE
Add severity sort option for scanner reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ hrbcli scanner scan <project>
 hrbcli scanner running <project>
 hrbcli scanner reports <project> --summary
 hrbcli scanner reports <project> --sort repo
+hrbcli scanner reports <project> --sort crit
 ```
 
 ### Distribution Commands

--- a/cmd/scanner.go
+++ b/cmd/scanner.go
@@ -227,6 +227,11 @@ func newScannerReportsCmd() *cobra.Command {
 				Reference  string      `json:"reference"`
 				Report     interface{} `json:"report"`
 				Count      int         `json:"count,omitempty"`
+				Critical   int         `json:"critical,omitempty"`
+				High       int         `json:"high,omitempty"`
+				Medium     int         `json:"medium,omitempty"`
+				Low        int         `json:"low,omitempty"`
+				Total      int         `json:"total,omitempty"`
 			}
 			var reports []entry
 
@@ -255,10 +260,18 @@ func newScannerReportsCmd() *cobra.Command {
 							output.Success("Saved report to %s", path)
 						} else {
 							c := 0
+							crit := 0
+							high := 0
+							med := 0
+							low := 0
 							for _, ov := range a.ScanOverview {
 								c += ov.Summary.Total
+								crit += ov.Summary.Summary["Critical"]
+								high += ov.Summary.Summary["High"]
+								med += ov.Summary.Summary["Medium"]
+								low += ov.Summary.Summary["Low"]
 							}
-							reports = append(reports, entry{Repository: r, Reference: ref, Report: a.ScanOverview, Count: c})
+							reports = append(reports, entry{Repository: r, Reference: ref, Report: a.ScanOverview, Count: c, Critical: crit, High: high, Medium: med, Low: low, Total: c})
 						}
 						continue
 					}
@@ -305,7 +318,23 @@ func newScannerReportsCmd() *cobra.Command {
 							if count == 0 && report.Summary.Total > 0 {
 								count = report.Summary.Total
 							}
-							reports = append(reports, entry{Repository: r, Reference: ref, Report: report, Count: count})
+
+							crit := report.Summary.Summary["Critical"]
+							high := report.Summary.Summary["High"]
+							med := report.Summary.Summary["Medium"]
+							low := report.Summary.Summary["Low"]
+
+							reports = append(reports, entry{
+								Repository: r,
+								Reference:  ref,
+								Report:     report,
+								Count:      count,
+								Critical:   crit,
+								High:       high,
+								Medium:     med,
+								Low:        low,
+								Total:      report.Summary.Total,
+							})
 						}
 					}
 				}
@@ -321,7 +350,8 @@ func newScannerReportsCmd() *cobra.Command {
 			}
 
 			sort.SliceStable(reports, func(i, j int) bool {
-				switch strings.ToLower(sortBy) {
+				field := strings.ToLower(sortBy)
+				switch field {
 				case "repo", "repository":
 					if reverse {
 						return reports[i].Repository > reports[j].Repository
@@ -332,11 +362,72 @@ func newScannerReportsCmd() *cobra.Command {
 						return reports[i].Reference > reports[j].Reference
 					}
 					return reports[i].Reference < reports[j].Reference
-				default:
+				case "vuln":
 					if reverse {
 						return reports[i].Count < reports[j].Count
 					}
 					return reports[i].Count > reports[j].Count
+				case "crit", "critical":
+					if reverse {
+						return reports[i].Critical < reports[j].Critical
+					}
+					return reports[i].Critical > reports[j].Critical
+				case "high":
+					if reverse {
+						return reports[i].High < reports[j].High
+					}
+					return reports[i].High > reports[j].High
+				case "med", "medium":
+					if reverse {
+						return reports[i].Medium < reports[j].Medium
+					}
+					return reports[i].Medium > reports[j].Medium
+				case "low":
+					if reverse {
+						return reports[i].Low < reports[j].Low
+					}
+					return reports[i].Low > reports[j].Low
+				case "total":
+					if reverse {
+						return reports[i].Total < reports[j].Total
+					}
+					return reports[i].Total > reports[j].Total
+				default:
+					// default severity sort
+					if reports[i].Critical != reports[j].Critical {
+						if reverse {
+							return reports[i].Critical < reports[j].Critical
+						}
+						return reports[i].Critical > reports[j].Critical
+					}
+					if reports[i].High != reports[j].High {
+						if reverse {
+							return reports[i].High < reports[j].High
+						}
+						return reports[i].High > reports[j].High
+					}
+					if reports[i].Medium != reports[j].Medium {
+						if reverse {
+							return reports[i].Medium < reports[j].Medium
+						}
+						return reports[i].Medium > reports[j].Medium
+					}
+					if reports[i].Low != reports[j].Low {
+						if reverse {
+							return reports[i].Low < reports[j].Low
+						}
+						return reports[i].Low > reports[j].Low
+					}
+					if reports[i].Total != reports[j].Total {
+						if reverse {
+							return reports[i].Total < reports[j].Total
+						}
+						return reports[i].Total > reports[j].Total
+					}
+					if reverse {
+						return reports[i].Repository > reports[j].Repository
+					}
+					return reports[i].Repository < reports[j].Repository
 				}
 			})
 
@@ -404,7 +495,7 @@ func newScannerReportsCmd() *cobra.Command {
 	cmd.Flags().StringVar(&reportType, "type", "vulnerability", "Report type (vulnerability|sbom)")
 	cmd.Flags().BoolVar(&summary, "summary", false, "Show summary instead of full report")
 	cmd.Flags().StringVar(&outputDir, "output-dir", "", "Directory to save reports")
-	cmd.Flags().StringVar(&sortBy, "sort", "vuln", "Sort by field (vuln|repo|ref)")
+	cmd.Flags().StringVar(&sortBy, "sort", "severity", "Sort by field (severity|crit|high|medium|low|total|vuln|repo|ref)")
 	cmd.Flags().BoolVar(&reverse, "reverse", false, "Reverse sort order")
 
 	return cmd

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -322,7 +322,7 @@ hrbcli scanner scan myproject/myrepo
 
 #### `hrbcli scanner reports`
 
-Retrieve vulnerability or SBOM reports for artifacts in a project or repository. When used with `--summary`, displays counts of vulnerabilities by severity for each artifact. Use `--output-dir` to download the reports for all artifacts to a directory. Results are sorted by vulnerability count by default; use `--sort` and `--reverse` to change ordering.
+Retrieve vulnerability or SBOM reports for artifacts in a project or repository. When used with `--summary`, displays counts of vulnerabilities by severity for each artifact. Use `--output-dir` to download the reports for all artifacts to a directory. Results are sorted by severity (critical, high, medium, low, total, repository) by default; use `--sort` and `--reverse` to change ordering.
 
 
 ```bash


### PR DESCRIPTION
## Summary
- support sorting scanner summary by severity counts
- default sort order: critical, high, medium, low, total, repository
- document new sorting options and example usage
- include severity counts for non-summary vulnerability reports so severity sorting works

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68487f6f70d48325856984c890f3d487